### PR TITLE
fix(core): ConfigValues.observe() does not react to remote provider changes

### DIFF
--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValues.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValues.kt
@@ -3,8 +3,11 @@
 package dev.androidbroadcast.featured
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 
 /**
  * A class that provides access to configuration values from both local and remote sources.
@@ -23,6 +26,8 @@ public class ConfigValues(
             "At least one provider (local or remote) must be provided."
         }
     }
+
+    private val fetchSignal = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
     public suspend fun <T : Any> getValue(param: ConfigParam<T>): ConfigValue<T> =
         localProvider?.get(param)
@@ -55,21 +60,35 @@ public class ConfigValues(
         localProvider?.resetOverride(param)
     }
 
+    /**
+     * Fetches the latest configuration values from the remote provider and activates them.
+     * Any active [observe] flows will re-emit the updated value for the observed parameter.
+     * Has no effect when no remote provider is configured.
+     */
     public suspend fun fetch() {
-        remoteProvider?.fetch(true)
+        if (remoteProvider == null) return
+        remoteProvider.fetch(true)
+        fetchSignal.emit(Unit)
     }
 
     /**
      * Observes changes to the configuration value for the given parameter.
-     * It emits the latest value immediately and then continues to emit updates
-     * whenever the value changes locally.
+     *
+     * Emits the latest value immediately, then continues to emit updates whenever:
+     * - the value changes via the local provider, **or**
+     * - [fetch] completes and the remote provider returns a new value.
      *
      * @param param The configuration parameter to observe.
-     * @return A flow of configuration values for the specified parameter.
+     * @return A [Flow] of [ConfigValue] for the specified parameter.
      */
-    public fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
-        flow<ConfigValue<T>> {
-            emit(getValue(param)) // get latest value
-            localProvider?.observe(param)?.collect { emit(it) } // observe changes
+    public fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> {
+        val localFlow = localProvider?.observe(param)
+        val remoteFlow = fetchSignal.map { getValue(param) }
+
+        return flow<ConfigValue<T>> {
+            emit(getValue(param))
+            val merged = if (localFlow != null) merge(localFlow, remoteFlow) else remoteFlow
+            merged.collect { emit(it) }
         }.distinctUntilChanged()
+    }
 }

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ConfigValuesTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ConfigValuesTest.kt
@@ -33,6 +33,55 @@ class ConfigValuesTest {
     }
 
     @Test
+    fun testObserveEmitsNewValueAfterRemoteFetch() =
+        runTest {
+            val remoteProvider = MockRemoteProvider()
+            val configValues = ConfigValues(remoteProvider = remoteProvider)
+            val param = ConfigParam("remote_flag", "default")
+
+            remoteProvider.setMockValue("remote_flag", "initial_remote")
+
+            configValues.observe(param).test {
+                // Should emit current remote value first
+                val firstEmission = awaitItem()
+                assertEquals("initial_remote", firstEmission.value)
+                assertEquals(ConfigValue.Source.REMOTE, firstEmission.source)
+
+                // Simulate remote update and fetch
+                remoteProvider.setMockValue("remote_flag", "updated_remote")
+                configValues.fetch()
+
+                // Should emit new value after fetch
+                val secondEmission = awaitItem()
+                assertEquals("updated_remote", secondEmission.value)
+                assertEquals(ConfigValue.Source.REMOTE, secondEmission.source)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun testObserveDoesNotEmitWhenFetchDoesNotChangeValue() =
+        runTest {
+            val remoteProvider = MockRemoteProvider()
+            val configValues = ConfigValues(remoteProvider = remoteProvider)
+            val param = ConfigParam("remote_flag", "default")
+
+            remoteProvider.setMockValue("remote_flag", "same_value")
+
+            configValues.observe(param).test {
+                val firstEmission = awaitItem()
+                assertEquals("same_value", firstEmission.value)
+
+                // Fetch without changing the remote value — should not emit again
+                configValues.fetch()
+                expectNoEvents()
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun testConfigValuesRequiresAtLeastOneProvider() {
         assertFailsWith<IllegalArgumentException> {
             ConfigValues(localProvider = null, remoteProvider = null)
@@ -195,8 +244,8 @@ class ConfigValuesTest {
                 assertEquals("remote_value", emission.value)
                 assertEquals(ConfigValue.Source.REMOTE, emission.source)
 
-                // Flow will complete since there's no local provider to observe changes
-                awaitComplete()
+                // Flow stays open — future fetch() calls can deliver updated remote values
+                cancelAndIgnoreRemainingEvents()
             }
         }
 


### PR DESCRIPTION
## Summary

- Introduces a `MutableSharedFlow<Unit> fetchSignal` inside `ConfigValues` that emits after each `fetch()` call
- `observe()` now merges the local provider's flow with a remote-update flow driven by `fetchSignal`, so active observers receive updated values whenever `fetch()` completes
- `fetch()` is guarded: signal only emits when a `remoteProvider` is configured, preventing spurious re-emissions when there is no remote source
- KDoc updated on both `fetch()` and `observe()` to document the reactive contract

## Test plan

- [x] `testObserveEmitsNewValueAfterRemoteFetch` — observer receives new remote value after `fetch()` updates the flag
- [x] `testObserveDoesNotEmitWhenFetchDoesNotChangeValue` — no spurious emission when value is unchanged (covered by `distinctUntilChanged`)
- [x] `testObserveWithoutLocalProvider` — updated to reflect that the flow now stays open (can receive future remote updates), rather than completing after one item
- [x] All 55 tests pass, ≥90% line coverage verified (`./gradlew :core:koverVerify`)
- [x] `spotlessCheck` passes

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)