### PR TITLE
docs: audit and complete KDoc on all public API declarations

### DIFF
--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigParam.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigParam.kt
@@ -4,6 +4,24 @@ package dev.androidbroadcast.featured
 
 import kotlin.reflect.KClass
 
+/**
+ * Declares a named, typed configuration key with a default value.
+ *
+ * A [ConfigParam] is a descriptor — it does not hold a live value itself. Pass it to
+ * [ConfigValues] to read, observe, or override the corresponding runtime value.
+ *
+ * Instances are considered equal when all constructor properties are equal. The hash code
+ * is derived solely from [key] so that params can be used as map keys with predictable
+ * behaviour.
+ *
+ * Prefer the inline factory function [ConfigParam] over the primary constructor to avoid
+ * passing an explicit [kotlin.reflect.KClass] argument:
+ * ```kotlin
+ * val darkMode = ConfigParam(key = "dark_mode", defaultValue = false)
+ * ```
+ *
+ * @param T The non-null type of the configuration value.
+ */
 public class ConfigParam<T : Any>
     @PublishedApi
     internal constructor(
@@ -85,6 +103,25 @@ private fun StringBuilder.appendIfPresent(
     return this
 }
 
+/**
+ * Creates a [ConfigParam] without requiring an explicit [kotlin.reflect.KClass] argument.
+ *
+ * The type parameter [T] is reified at the call site, so the compiler fills in [valueType]
+ * automatically.
+ *
+ * ```kotlin
+ * val maxRetries = ConfigParam(key = "max_retries", defaultValue = 3)
+ * val theme = ConfigParam(key = "theme", defaultValue = "light", description = "App colour theme")
+ * ```
+ *
+ * @param T The non-null type of the configuration value.
+ * @param key Unique identifier used to look up this parameter in providers.
+ * @param defaultValue Value returned when no provider supplies a value for this key.
+ * @param description Optional human-readable explanation shown in debug UIs.
+ * @param category Optional group name used to organise related params in debug UIs.
+ * @param since Optional version or date string indicating when this param was introduced.
+ * @return A [ConfigParam] instance typed to [T].
+ */
 public inline fun <reified T : Any> ConfigParam(
     key: String,
     defaultValue: T,

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValue.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValue.kt
@@ -1,5 +1,17 @@
 package dev.androidbroadcast.featured
 
+/**
+ * A snapshot of a single configuration parameter's resolved value together with its origin.
+ *
+ * [ConfigValues] produces [ConfigValue] instances when you call [ConfigValues.getValue] or
+ * collect from [ConfigValues.observe]. The [source] property lets callers distinguish between
+ * a hard-coded default, a locally persisted override, and a value fetched from a remote
+ * configuration service.
+ *
+ * @param T The non-null type of the configuration value.
+ * @property value The resolved value of the configuration parameter.
+ * @property source Where this value originates; see [Source] for the full list of origins.
+ */
 public data class ConfigValue<T : Any>(
     /**
      * The value of the configuration parameter.
@@ -45,9 +57,42 @@ public data class ConfigValue<T : Any>(
     }
 }
 
+/**
+ * Transforms the [ConfigValue.value] while preserving the original [ConfigValue.source].
+ *
+ * Useful for mapping a raw configuration value to a domain type without losing provenance
+ * information:
+ * ```kotlin
+ * val themeValue: ConfigValue<String> = configValues.getValue(themeParam)
+ * val theme: ConfigValue<Theme> = themeValue.map { Theme.fromKey(it) }
+ * ```
+ *
+ * @param T The original value type.
+ * @param R The mapped value type.
+ * @param transform Function applied to [ConfigValue.value].
+ * @return A new [ConfigValue] with the transformed value and the same [ConfigValue.source].
+ */
 public inline fun <T : Any, R : Any> ConfigValue<T>.map(transform: (T) -> R): ConfigValue<R> =
     ConfigValue(value = transform(value), source = source)
 
+/**
+ * Executes [action] when [predicate] returns `true`, otherwise executes [elseAction].
+ *
+ * Both branches receive the full [ConfigValue] receiver, preserving source information.
+ *
+ * ```kotlin
+ * configValues.getValue(featureParam).doIf(
+ *     predicate = { it.value },
+ *     action    = { enableFeature() },
+ *     elseAction = { disableFeature() },
+ * )
+ * ```
+ *
+ * @param T The non-null value type.
+ * @param predicate Condition evaluated against this [ConfigValue].
+ * @param action Executed when [predicate] returns `true`.
+ * @param elseAction Executed when [predicate] returns `false`; defaults to a no-op.
+ */
 public inline fun <T : Any> ConfigValue<T>.doIf(
     predicate: (ConfigValue<T>) -> Boolean,
     action: (ConfigValue<T>) -> Unit,

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValues.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValues.kt
@@ -10,12 +10,34 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 
 /**
- * A class that provides access to configuration values from both local and remote sources.
- * Local values are typically used for user-specific overrides and have higher priority,
- * while remote values are fetched from a remote configuration service.
+ * Central access point for reading, overriding, and observing configuration values.
  *
- * If both local and remote values are available, the local value will be returned.
- * If neither is available, the default value from the parameter will be returned.
+ * [ConfigValues] composes an optional [LocalConfigValueProvider] and an optional
+ * [RemoteConfigValueProvider] using a well-defined priority order:
+ * 1. **Local provider** — highest priority; used for user-specific overrides.
+ * 2. **Remote provider** — values fetched from a remote configuration service.
+ * 3. **Default** — [ConfigParam.defaultValue] is used when no provider returns a value.
+ *
+ * At least one provider must be supplied; passing `null` for both throws [IllegalArgumentException].
+ *
+ * ```kotlin
+ * val configValues = ConfigValues(
+ *     localProvider  = InMemoryConfigValueProvider(),
+ *     remoteProvider = FirebaseConfigValueProvider(),
+ * )
+ *
+ * // One-shot read
+ * val value: ConfigValue<Boolean> = configValues.getValue(DarkModeParam)
+ *
+ * // Reactive observation
+ * configValues.observe(DarkModeParam).collect { configValue ->
+ *     applyTheme(configValue.value)
+ * }
+ * ```
+ *
+ * @param localProvider Optional provider for locally persisted overrides.
+ * @param remoteProvider Optional provider for remote configuration values.
+ * @throws IllegalArgumentException if both [localProvider] and [remoteProvider] are `null`.
  */
 public class ConfigValues(
     private val localProvider: LocalConfigValueProvider? = null,
@@ -29,6 +51,14 @@ public class ConfigValues(
 
     private val fetchSignal = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
+    /**
+     * Returns the current value for [param], applying provider priority.
+     *
+     * Priority order: local provider → remote provider → [ConfigParam.defaultValue].
+     *
+     * @param param The configuration parameter to read.
+     * @return The resolved [ConfigValue], never `null`.
+     */
     public suspend fun <T : Any> getValue(param: ConfigParam<T>): ConfigValue<T> =
         localProvider?.get(param)
             ?: remoteProvider?.get(param)

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValuesExtensions.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValuesExtensions.kt
@@ -7,8 +7,43 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
+/**
+ * Returns a [Flow] that emits the unwrapped value for [param] on every change.
+ *
+ * This is a convenience wrapper around [ConfigValues.observe] that strips the
+ * [ConfigValue] envelope so callers only see the raw [T] values.
+ *
+ * ```kotlin
+ * configValues.observeValue(DarkModeParam).collect { isDark ->
+ *     applyTheme(isDark)
+ * }
+ * ```
+ *
+ * @param param The configuration parameter to observe.
+ * @return A [Flow] of unwrapped values; emits immediately and on every subsequent change.
+ */
 public fun <T : Any> ConfigValues.observeValue(param: ConfigParam<T>): Flow<T> = observe(param).map { it.value }
 
+/**
+ * Converts the [ConfigValues.observe] flow for [param] into a [StateFlow].
+ *
+ * The [StateFlow] is shared within [scope] according to the [started] policy. The initial
+ * value is [ConfigParam.defaultValue], ensuring the [StateFlow] is never empty.
+ *
+ * ```kotlin
+ * val isDark: StateFlow<Boolean> = configValues.asStateFlow(
+ *     param   = DarkModeParam,
+ *     scope   = viewModelScope,
+ *     started = SharingStarted.WhileSubscribed(5_000),
+ * )
+ * ```
+ *
+ * @param param The configuration parameter to observe.
+ * @param scope The [CoroutineScope] that governs the sharing coroutine's lifetime.
+ * @param started Controls when sharing starts and stops; defaults to
+ *   [SharingStarted.WhileSubscribed] with a 5-second replay timeout.
+ * @return A [StateFlow] whose value is always the latest unwrapped configuration value.
+ */
 public fun <T : Any> ConfigValues.asStateFlow(
     param: ConfigParam<T>,
     scope: CoroutineScope,

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProvider.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProvider.kt
@@ -7,10 +7,34 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.mapNotNull
 
+/**
+ * A [LocalConfigValueProvider] that stores configuration overrides in memory.
+ *
+ * Values are held in a plain [Map] and are lost when the process terminates. This makes
+ * [InMemoryConfigValueProvider] ideal for tests, Compose previews, and ephemeral runtime
+ * overrides that do not need to survive process death.
+ *
+ * [set] and [resetOverride] emit a change signal that causes active [observe] flows to
+ * re-evaluate and emit the updated value. [clear] does not emit signals — see its KDoc.
+ *
+ * ```kotlin
+ * val provider = InMemoryConfigValueProvider()
+ * val configValues = ConfigValues(localProvider = provider)
+ *
+ * provider.set(DarkModeParam, true)
+ * val value = configValues.getValue(DarkModeParam) // ConfigValue(true, LOCAL)
+ * ```
+ */
 public class InMemoryConfigValueProvider : LocalConfigValueProvider {
     private var storage: Map<String, Any> = emptyMap()
     private val changedKeyFlow = MutableSharedFlow<String>(extraBufferCapacity = 1000)
 
+    /**
+     * Returns the locally stored value for [param], or `null` if no override has been set.
+     *
+     * @param param The configuration parameter to look up.
+     * @return A [ConfigValue] with [ConfigValue.Source.LOCAL], or `null` if not present.
+     */
     @Suppress("UNCHECKED_CAST")
     override suspend fun <T : Any> get(param: ConfigParam<T>): ConfigValue<T>? =
         storage[param.key]?.let { value ->
@@ -20,6 +44,12 @@ public class InMemoryConfigValueProvider : LocalConfigValueProvider {
             )
         }
 
+    /**
+     * Stores [value] as a local override for [param] and notifies active [observe] flows.
+     *
+     * @param param The configuration parameter to override.
+     * @param value The value to store.
+     */
     public override suspend fun <T : Any> set(
         param: ConfigParam<T>,
         value: T,
@@ -28,15 +58,40 @@ public class InMemoryConfigValueProvider : LocalConfigValueProvider {
         changedKeyFlow.emit(param.key)
     }
 
+    /**
+     * Removes the stored override for [param] and notifies active [observe] flows.
+     *
+     * After this call, [get] returns `null` for [param] and [ConfigValues] falls back to
+     * the remote provider or [ConfigParam.defaultValue].
+     *
+     * @param param The configuration parameter whose override should be cleared.
+     */
     public override suspend fun <T : Any> resetOverride(param: ConfigParam<T>) {
         storage = storage - param.key
         changedKeyFlow.emit(param.key)
     }
 
+    /**
+     * Removes all stored overrides, resetting the provider to an empty state.
+     *
+     * Unlike [resetOverride], this does **not** emit change signals. Callers that need
+     * reactive updates after a bulk clear should call [resetOverride] per param instead.
+     */
     public fun clear() {
         storage = emptyMap()
     }
 
+    /**
+     * Returns a [kotlinx.coroutines.flow.Flow] that emits the current value for [param]
+     * immediately (if an override exists) and then emits again on every subsequent [set]
+     * or [resetOverride] call for the same key.
+     *
+     * The flow completes only when the collector's scope is cancelled. It does **not** emit
+     * after [clear] because [clear] does not signal individual key changes.
+     *
+     * @param param The configuration parameter to observe.
+     * @return A cold [kotlinx.coroutines.flow.Flow] of [ConfigValue] snapshots.
+     */
     override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
         flow {
             get(param)?.let { emit(it) }

--- a/datastore-provider/src/commonMain/kotlin/dev/androidbroadcast/featured/datastore/DataStoreConfigValueProvider.kt
+++ b/datastore-provider/src/commonMain/kotlin/dev/androidbroadcast/featured/datastore/DataStoreConfigValueProvider.kt
@@ -16,9 +16,34 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
+/**
+ * A [LocalConfigValueProvider] backed by AndroidX [DataStore] with [Preferences].
+ *
+ * Values are persisted across process restarts using the Preferences DataStore. Only the
+ * following types are supported: [String], [Int], [Long], [Float], [Double], [Boolean].
+ * Attempting to read or write an unsupported type throws [IllegalArgumentException].
+ *
+ * All write operations ([set], [resetOverride]) trigger a DataStore update, which in turn
+ * causes any active [observe] flow to re-emit.
+ *
+ * ```kotlin
+ * val dataStore: DataStore<Preferences> = context.createDataStore("feature_flags")
+ * val provider = DataStoreConfigValueProvider(dataStore)
+ * val configValues = ConfigValues(localProvider = provider)
+ * ```
+ *
+ * @param dataStore The [DataStore] instance used to read and write preference values.
+ */
 public class DataStoreConfigValueProvider(
     private val dataStore: DataStore<Preferences>,
 ) : LocalConfigValueProvider {
+    /**
+     * Returns the persisted value for [param], or `null` if it has not been set.
+     *
+     * @param param The configuration parameter to look up.
+     * @return A [ConfigValue] with [ConfigValue.Source.LOCAL], or `null` if not present.
+     * @throws IllegalArgumentException if the type of [param] is not supported.
+     */
     override suspend fun <T : Any> get(param: ConfigParam<T>): ConfigValue<T>? {
         val preferences = dataStore.data.first()
         val key = createPreferencesKey(param)
@@ -37,6 +62,16 @@ public class DataStoreConfigValueProvider(
         }
     }
 
+    /**
+     * Persists [value] as a local override for [param].
+     *
+     * Active [observe] flows for the same [param] will re-emit after the DataStore write
+     * completes.
+     *
+     * @param param The configuration parameter to override.
+     * @param value The value to persist.
+     * @throws IllegalArgumentException if the type of [param] is not supported.
+     */
     override suspend fun <T : Any> set(
         param: ConfigParam<T>,
         value: T,
@@ -46,12 +81,31 @@ public class DataStoreConfigValueProvider(
         }
     }
 
+    /**
+     * Removes the persisted override for [param].
+     *
+     * After this call, [get] returns `null` for [param] and [ConfigValues] falls back to
+     * the remote provider or [ConfigParam.defaultValue].
+     *
+     * @param param The configuration parameter whose override should be cleared.
+     * @throws IllegalArgumentException if the type of [param] is not supported.
+     */
     override suspend fun <T : Any> resetOverride(param: ConfigParam<T>) {
         dataStore.edit { preferences ->
             preferences.remove(createPreferencesKey(param))
         }
     }
 
+    /**
+     * Returns a [Flow] that emits a [ConfigValue] for [param] on every DataStore update.
+     *
+     * The flow emits immediately with the current persisted value (or [ConfigParam.defaultValue]
+     * when no override is set) and then continues to emit on every subsequent change.
+     *
+     * @param param The configuration parameter to observe.
+     * @return A [Flow] backed by the DataStore; completes when the collector's scope is cancelled.
+     * @throws IllegalArgumentException if the type of [param] is not supported.
+     */
     override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
         dataStore.data.map { preferences ->
             val key = createPreferencesKey(param)
@@ -68,6 +122,9 @@ public class DataStoreConfigValueProvider(
         }
 
     public companion object {
+        /**
+         * Stable identifier for this provider; may be used for logging or dependency injection.
+         */
         public const val ID: String = "dev.androidbroadcast.featured.datastore"
     }
 }

--- a/featured-compose/src/commonMain/kotlin/dev/androidbroadcast/featured/compose/ConfigValuesComposeExtensions.kt
+++ b/featured-compose/src/commonMain/kotlin/dev/androidbroadcast/featured/compose/ConfigValuesComposeExtensions.kt
@@ -7,6 +7,23 @@ import dev.androidbroadcast.featured.ConfigParam
 import dev.androidbroadcast.featured.ConfigValues
 import dev.androidbroadcast.featured.observeValue
 
+/**
+ * Collects the current value for [param] from this [ConfigValues] as Compose [State].
+ *
+ * The returned [State] is initialised with [ConfigParam.defaultValue] and updates
+ * automatically whenever the underlying [ConfigValues.observe] flow emits a new value.
+ *
+ * ```kotlin
+ * @Composable
+ * fun MyScreen(configValues: ConfigValues) {
+ *     val isDarkMode by configValues.collectAsState(DarkModeParam)
+ *     // recomposes whenever the flag changes
+ * }
+ * ```
+ *
+ * @param param The configuration parameter to observe.
+ * @return A [State] whose value is always the latest resolved configuration value.
+ */
 @Composable
 public fun <T : Any> ConfigValues.collectAsState(param: ConfigParam<T>): State<T> =
     observeValue(param).collectAsState(initial = param.defaultValue)

--- a/firebase-provider/src/main/kotlin/dev/androidbroadcast/featured/firebase/Converter.kt
+++ b/firebase-provider/src/main/kotlin/dev/androidbroadcast/featured/firebase/Converter.kt
@@ -3,7 +3,25 @@ package dev.androidbroadcast.featured.firebase
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue
 import kotlin.ranges.contains
 
+/**
+ * Converts a raw [FirebaseRemoteConfigValue] to a typed value [T].
+ *
+ * Implement this functional interface to add support for custom types in
+ * [FirebaseConfigValueProvider.converters]:
+ * ```kotlin
+ * provider.converters.put<Theme>(Converter { Theme.fromKey(it.asString()) })
+ * ```
+ *
+ * @param T The non-null target type produced by [convert].
+ */
 public fun interface Converter<T : Any> {
+    /**
+     * Converts [value] from Firebase to a typed [T].
+     *
+     * @param value The raw Firebase Remote Config value.
+     * @return The converted value.
+     * @throws IllegalArgumentException if the raw value cannot be converted to [T].
+     */
     public fun convert(value: FirebaseRemoteConfigValue): T
 }
 

--- a/firebase-provider/src/main/kotlin/dev/androidbroadcast/featured/firebase/Converters.kt
+++ b/firebase-provider/src/main/kotlin/dev/androidbroadcast/featured/firebase/Converters.kt
@@ -2,9 +2,26 @@ package dev.androidbroadcast.featured.firebase
 
 import kotlin.reflect.KClass
 
+/**
+ * A mutable, type-keyed registry of [Converter] instances used by [FirebaseConfigValueProvider].
+ *
+ * Built-in converters for [String], [Boolean], [Int], [Long], [Double], and [Float] are
+ * pre-registered by [FirebaseConfigValueProvider]. Add custom converters via [put] or [set]:
+ * ```kotlin
+ * provider.converters[MyEnum::class] = Converter { MyEnum.fromString(it.asString()) }
+ * // or using the inline helper:
+ * provider.converters.put<MyEnum>(Converter { MyEnum.fromString(it.asString()) })
+ * ```
+ */
 public class Converters internal constructor() {
     private val converters = mutableMapOf<KClass<*>, Converter<*>>()
 
+    /**
+     * Registers [converter] for [klass], replacing any previously registered converter.
+     *
+     * @param klass The [KClass] of the type this converter handles.
+     * @param converter The [Converter] to register.
+     */
     public operator fun <T : Any> set(
         klass: KClass<T>,
         converter: Converter<T>,
@@ -12,15 +29,44 @@ public class Converters internal constructor() {
         converters[klass] = converter
     }
 
+    /**
+     * Returns the [Converter] registered for [klass], or `null` if none is registered.
+     *
+     * @param klass The [KClass] to look up.
+     * @return The registered [Converter], or `null`.
+     */
     @Suppress("UNCHECKED_CAST")
     public operator fun <T : Any> get(klass: KClass<T>): Converter<T>? = converters[klass] as Converter<T>?
 
+    /**
+     * Returns the [Converter] registered for [klass].
+     *
+     * @param klass The [KClass] to look up.
+     * @return The registered [Converter].
+     * @throws NoSuchElementException if no converter is registered for [klass].
+     */
     @Suppress("UNCHECKED_CAST")
     public fun <T : Any> getValue(klass: KClass<T>): Converter<T> = converters.getValue(klass) as Converter<T>
 
+    /**
+     * Returns `true` if a converter is registered for [klass].
+     *
+     * @param klass The [KClass] to check.
+     */
     public operator fun contains(klass: KClass<*>): Boolean = klass in converters
 }
 
+/**
+ * Registers [converter] for the reified type [T], replacing any previously registered converter.
+ *
+ * Inline convenience wrapper around [Converters.set] that avoids passing an explicit [KClass]:
+ * ```kotlin
+ * converters.put<Theme>(Converter { Theme.fromKey(it.asString()) })
+ * ```
+ *
+ * @param T The non-null type this converter handles.
+ * @param converter The [Converter] to register.
+ */
 public inline fun <reified T : Any> Converters.put(converter: Converter<T>) {
     set(T::class, converter)
 }

--- a/firebase-provider/src/main/kotlin/dev/androidbroadcast/featured/firebase/FirebaseConfigValueProvider.kt
+++ b/firebase-provider/src/main/kotlin/dev/androidbroadcast/featured/firebase/FirebaseConfigValueProvider.kt
@@ -8,9 +8,31 @@ import dev.androidbroadcast.featured.RemoteConfigValueProvider
 import kotlinx.coroutines.tasks.await
 import kotlin.reflect.KClass
 
+/**
+ * A [RemoteConfigValueProvider] backed by Firebase Remote Config.
+ *
+ * Reads values from [FirebaseRemoteConfig] and maps them to typed [ConfigValue] instances.
+ * The value source reported in [ConfigValue.source] reflects the Firebase source constant
+ * (`VALUE_SOURCE_REMOTE`, `VALUE_SOURCE_DEFAULT`, `VALUE_SOURCE_STATIC`).
+ *
+ * Out-of-the-box converters are registered for [String], [Boolean], [Int], [Long],
+ * [Double], and [Float]. Custom converters can be added via [converters]:
+ * ```kotlin
+ * val provider = FirebaseConfigValueProvider()
+ * provider.converters.put<MyEnum>(Converter { MyEnum.fromString(it.asString()) })
+ * ```
+ *
+ * @param remoteConfig The [FirebaseRemoteConfig] instance to read from.
+ *   Defaults to [FirebaseRemoteConfig.getInstance].
+ */
 public class FirebaseConfigValueProvider(
     private val remoteConfig: FirebaseRemoteConfig = FirebaseRemoteConfig.getInstance(),
 ) : RemoteConfigValueProvider {
+    /**
+     * Mutable registry of type converters used to extract typed values from Firebase.
+     *
+     * Modify this property to add support for custom types before calling [get].
+     */
     public val converters: Converters =
         Converters().apply {
             put<String>(Converter(FirebaseRemoteConfigValue::asString))
@@ -21,6 +43,16 @@ public class FirebaseConfigValueProvider(
             put<Float>(FloatConverter())
         }
 
+    /**
+     * Returns the current Firebase Remote Config value for [param].
+     *
+     * Always returns a non-null [ConfigValue]; Firebase provides a value for every key
+     * (falling back to static defaults when no remote or default value exists).
+     *
+     * @param param The configuration parameter to read.
+     * @return A [ConfigValue] whose [ConfigValue.source] reflects the Firebase value origin.
+     * @throws IllegalStateException if no converter is registered for the type of [param].
+     */
     override suspend fun <T : Any> get(param: ConfigParam<T>): ConfigValue<T>? =
         remoteConfig.getValue(param.key).let { remoteValue ->
             ConfigValue(
@@ -37,6 +69,12 @@ public class FirebaseConfigValueProvider(
         return converter.convert(this)
     }
 
+    /**
+     * Fetches the latest values from Firebase Remote Config and optionally activates them.
+     *
+     * @param activate When `true`, calls `fetchAndActivate()` so values become available
+     *   immediately after this call. When `false`, only fetches without activating.
+     */
     override suspend fun fetch(activate: Boolean) {
         val task =
             when (activate) {

--- a/sharedpreferences-provider/src/main/kotlin/dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfig.kt
+++ b/sharedpreferences-provider/src/main/kotlin/dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfig.kt
@@ -19,8 +19,27 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
 /**
- * Implementation of FeatureFlagProvider that uses Android SharedPreferences for local storage.
- * This provider stores and retrieves feature flags from the device's local storage.
+ * A [LocalConfigValueProvider] backed by Android [SharedPreferences].
+ *
+ * Values are persisted in the provided [SharedPreferences] file and survive process restarts.
+ * All reads and writes are dispatched on [kotlinx.coroutines.Dispatchers.IO] merged with an
+ * optional caller-supplied [CoroutineContext].
+ *
+ * Supported value types: [String], [Int], [Long], [Float], [Double], [Boolean].
+ * Attempting to read or write an unsupported type throws [IllegalArgumentException].
+ *
+ * Active [observe] flows receive updates whenever [set], [resetOverride], or [remove] is called
+ * for the observed key.
+ *
+ * ```kotlin
+ * val prefs = context.getSharedPreferences("feature_flags", Context.MODE_PRIVATE)
+ * val provider = SharedPreferencesProviderConfig(prefs)
+ * val configValues = ConfigValues(localProvider = provider)
+ * ```
+ *
+ * @param sharedPreferences The [SharedPreferences] instance used for persistence.
+ * @param context Additional [CoroutineContext] elements merged with [kotlinx.coroutines.Dispatchers.IO]
+ *   for all IO-bound operations. Defaults to [EmptyCoroutineContext].
  */
 public class SharedPreferencesProviderConfig(
     private val sharedPreferences: SharedPreferences,
@@ -41,6 +60,13 @@ public class SharedPreferencesProviderConfig(
         }
     }
 
+    /**
+     * Returns the persisted value for [param], or `null` if it has not been set.
+     *
+     * @param param The configuration parameter to look up.
+     * @return A [ConfigValue] with [ConfigValue.Source.LOCAL], or `null` if not present.
+     * @throws IllegalArgumentException if the type of [param] is not supported.
+     */
     override suspend fun <T : Any> get(param: ConfigParam<T>): ConfigValue<T>? =
         withContext(context) {
             val valueSaver =
@@ -51,6 +77,15 @@ public class SharedPreferencesProviderConfig(
             }
         }
 
+    /**
+     * Persists [value] as a local override for [param] and notifies active [observe] flows.
+     *
+     * The write is performed with `commit = true` (synchronous) on the IO dispatcher.
+     *
+     * @param param The configuration parameter to override.
+     * @param value The value to persist.
+     * @throws IllegalArgumentException if the type of [param] is not supported.
+     */
     override suspend fun <T : Any> set(
         param: ConfigParam<T>,
         value: T,
@@ -65,6 +100,14 @@ public class SharedPreferencesProviderConfig(
             changedKeysFlow.tryEmit(param.key)
         }
 
+    /**
+     * Removes the persisted override for [param], delegating to [remove].
+     *
+     * After this call, [get] returns `null` and [ConfigValues] falls back to the remote
+     * provider or [ConfigParam.defaultValue].
+     *
+     * @param param The configuration parameter whose override should be cleared.
+     */
     override suspend fun <T : Any> resetOverride(param: ConfigParam<T>): Unit = remove(param.key)
 
     /**
@@ -90,6 +133,16 @@ public class SharedPreferencesProviderConfig(
             }
         }
 
+    /**
+     * Returns a [Flow] that emits a [ConfigValue] for [param] on every change to its key.
+     *
+     * The flow emits the current persisted value immediately (skipping `null` if unset) and
+     * then emits again whenever [set], [resetOverride], or [remove] is called for the same
+     * key. Consecutive identical values are deduplicated via `distinctUntilChanged`.
+     *
+     * @param param The configuration parameter to observe.
+     * @return A cold [Flow] that completes when the collector's scope is cancelled.
+     */
     override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> {
         return flow<ConfigValue<T>?> {
             emit(get(param)) // Emit the current value first


### PR DESCRIPTION
## Summary

Closes #64

- Adds class-level KDoc with usage examples to `ConfigParam`, `ConfigValue`, `ConfigValues`, `InMemoryConfigValueProvider`, `DataStoreConfigValueProvider`, `SharedPreferencesProviderConfig`, `FirebaseConfigValueProvider`, `Converter`, and `Converters`
- Adds `@param`/`@return`/`@throws` to every public method across all modules (core, datastore-provider, sharedpreferences-provider, firebase-provider, featured-compose)
- Adds KDoc to extension functions: `observeValue`, `asStateFlow`, `collectAsState`, `ConfigValue.map`, `ConfigValue.doIf`, `Converters.put`
- Accurately documents provider priority order, reactive update semantics, and supported types for each provider

## Test plan

- [ ] `./gradlew :core:test` passes (46 tests)
- [ ] `./gradlew :core:koverVerify` passes (≥90% line coverage)
- [ ] `./gradlew spotlessCheck` passes (no formatting issues)
- [ ] `./gradlew test` passes across all modules (329 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)