### PR TITLE
feat(ios): publish XCFramework as Swift Package Manager artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,3 +47,69 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}
           ORG_GRADLE_PROJECT_VERSION_NAME: ${{ steps.version.outputs.VERSION_NAME }}
         run: ./gradlew --no-daemon publishAllPublicationsToMavenCentralRepository
+
+  publish-xcframework:
+    name: Publish XCFramework to GitHub Release
+    # Only runs for version tags — not for SNAPSHOT pushes to main.
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: macos-latest
+    permissions:
+      contents: write  # Required to upload release assets and update Package.swift
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v3
+
+      - name: Build XCFramework
+        run: ./gradlew --no-daemon :core:zipXCFramework
+
+      - name: Compute checksum
+        id: checksum
+        run: |
+          CHECKSUM=$(swift package compute-checksum core/build/xcframeworks/FeaturedCore.xcframework.zip)
+          echo "CHECKSUM=${CHECKSUM}" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Create or update GitHub Release and upload XCFramework
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create the release if it doesn't already exist (idempotent)
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            2>/dev/null || true
+          gh release upload "${{ github.ref_name }}" \
+            core/build/xcframeworks/FeaturedCore.xcframework.zip \
+            --clobber
+
+      - name: Update Package.swift checksum and URL
+        env:
+          TAG: ${{ github.ref_name }}
+          CHECKSUM: ${{ steps.checksum.outputs.CHECKSUM }}
+        run: |
+          ASSET_URL="https://github.com/AndroidBroadcast/Featured/releases/download/${TAG}/FeaturedCore.xcframework.zip"
+          sed -i '' \
+            -e "s|url: \".*FeaturedCore.xcframework.zip\"|url: \"${ASSET_URL}\"|" \
+            -e "s|checksum: \"[0-9a-f]*\"|checksum: \"${CHECKSUM}\"|" \
+            Package.swift
+
+      - name: Commit updated Package.swift
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Package.swift
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore: update Package.swift checksum for ${{ github.ref_name }}"
+          # Fetch latest main first to reduce push conflicts
+          git fetch origin main
+          git push origin HEAD:main

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+//
+// This file is auto-managed: the `url` and `checksum` fields are updated automatically
+// by the publish CI workflow when a new release is tagged.
+
+import PackageDescription
+
+let package = Package(
+    name: "Featured",
+    platforms: [
+        .iOS(.v16),
+    ],
+    products: [
+        .library(
+            name: "FeaturedCore",
+            targets: ["FeaturedCore"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "FeaturedCore",
+            // Updated automatically by CI on each release.
+            url: "https://github.com/AndroidBroadcast/Featured/releases/download/v0.0.0/FeaturedCore.xcframework.zip",
+            checksum: "0000000000000000000000000000000000000000000000000000000000000000"
+        ),
+    ]
+)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -5,6 +5,7 @@ import co.touchlab.skie.configuration.SealedInterop
 import co.touchlab.skie.configuration.SuspendInterop
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -25,6 +26,7 @@ kotlin {
         }
     }
 
+    val xcf = XCFramework("FeaturedCore")
     listOf(
         iosX64(),
         iosArm64(),
@@ -33,6 +35,7 @@ kotlin {
         iosTarget.binaries.framework {
             baseName = "FeaturedCore"
             isStatic = true
+            xcf.add(this)
         }
     }
 
@@ -52,6 +55,20 @@ kotlin {
             }
         }
     }
+}
+
+// Zips the release XCFramework for distribution via Swift Package Manager.
+// Output: build/xcframeworks/FeaturedCore.xcframework.zip
+val zipXCFramework by tasks.registering(Zip::class) {
+    description = "Zips the release FeaturedCore XCFramework for SPM distribution"
+    group = "build"
+
+    dependsOn("assembleFeaturedCoreReleaseXCFramework")
+
+    from(layout.buildDirectory.dir("XCFrameworks/release"))
+    include("FeaturedCore.xcframework/**")
+    archiveFileName.set("FeaturedCore.xcframework.zip")
+    destinationDirectory.set(layout.buildDirectory.dir("xcframeworks"))
 }
 
 android {


### PR DESCRIPTION
## Summary

- Adds `XCFramework()` DSL to `core/build.gradle.kts`, which unlocks the `assembleFeaturedCoreXCFramework` / `assembleFeaturedCoreReleaseXCFramework` Gradle tasks from the KMP plugin
- Registers a `zipXCFramework` task that zips the release XCFramework to `core/build/xcframeworks/FeaturedCore.xcframework.zip`
- Creates `Package.swift` at repo root declaring a binary SPM target; URL and checksum are placeholder values updated automatically by CI on each tagged release
- Extends `publish.yml` with a `publish-xcframework` job (runs on `macos-latest`, tag pushes only) that builds the zip, computes the Swift checksum via `swift package compute-checksum`, creates/updates the GitHub Release, uploads the asset, and commits the refreshed `Package.swift` back to main

Closes #51

## Test plan

- [x] `./gradlew :core:tasks | grep XCFramework` confirms `assembleFeaturedCoreXCFramework` and `assembleFeaturedCoreReleaseXCFramework` tasks exist
- [x] `./gradlew :core:tasks | grep zipXCFramework` confirms zip task exists
- [x] `./gradlew --no-daemon test` — all 315 tests pass
- [x] `./gradlew --no-daemon :core:koverVerify` — ≥90% line coverage maintained
- [x] `./gradlew --no-daemon spotlessCheck` — no formatting issues
- [ ] On next version tag push, verify CI `publish-xcframework` job builds and uploads `FeaturedCore.xcframework.zip` to GitHub Release and commits updated `Package.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)