### PR TITLE
feat(docs): set up Dokka for API reference generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,34 @@
+name: Publish Docs
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-docs:
+    name: Generate and Publish API Docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-build-env
+
+      - name: Generate Dokka HTML
+        run: ./gradlew --no-daemon dokkaHtmlMultiModule
+
+      - name: Publish to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/dokka/htmlMultiModule
+          destination_dir: api

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.kotlinJvm) apply false
     alias(libs.plugins.spotless)
     alias(libs.plugins.mavenPublish) apply false
+    alias(libs.plugins.dokka)
 }
 
 spotless {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     alias(libs.plugins.kover)
     alias(libs.plugins.bcv)
     alias(libs.plugins.mavenPublish)
+    alias(libs.plugins.dokka)
 }
 
 kotlin {

--- a/datastore-provider/build.gradle.kts
+++ b/datastore-provider/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.skie)
     alias(libs.plugins.mavenPublish)
+    alias(libs.plugins.dokka)
 }
 
 kotlin {

--- a/featured-compose/build.gradle.kts
+++ b/featured-compose/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.mavenPublish)
+    alias(libs.plugins.dokka)
 }
 
 kotlin {

--- a/featured-debug-ui/build.gradle.kts
+++ b/featured-debug-ui/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.mavenPublish)
+    alias(libs.plugins.dokka)
 }
 
 kotlin {

--- a/featured-registry/build.gradle.kts
+++ b/featured-registry/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.mavenPublish)
+    alias(libs.plugins.dokka)
 }
 
 kotlin {

--- a/firebase-provider/build.gradle.kts
+++ b/firebase-provider/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.mavenPublish)
+    alias(libs.plugins.dokka)
 }
 
 android {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,6 @@ android.useAndroidX=true
 
 #Publishing
 VERSION_NAME=0.1.0-SNAPSHOT
+
+#Dokka
+org.jetbrains.dokka.experimental.gradle.pluginMode=V1Enabled

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ ktlint = "1.8.0"
 bcv = "0.18.1"
 turbine = "1.2.1"
 mavenPublish = "0.32.0"
+dokka = "2.0.0"
 
 [libraries]
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
@@ -76,3 +77,4 @@ skie = { id = "co.touchlab.skie", version.ref = "skie" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 bcv = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "bcv" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }

--- a/sharedpreferences-provider/build.gradle.kts
+++ b/sharedpreferences-provider/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.mavenPublish)
+    alias(libs.plugins.dokka)
 }
 
 android {


### PR DESCRIPTION
## Summary

- Add `org.jetbrains.dokka` 2.0.0 to the version catalog and apply it to the root build (enables `dokkaHtmlMultiModule` aggregation)
- Apply the `dokka` plugin to all 7 public modules: `core`, `featured-compose`, `featured-registry`, `featured-debug-ui`, `datastore-provider`, `firebase-provider`, `sharedpreferences-provider`
- Pin Dokka V1 mode via `gradle.properties` to preserve the `dokkaHtmlMultiModule` task name specified in the acceptance criteria (V1 is fully functional in 2.0.0; V2 migration can be a follow-up)
- Add `.github/workflows/docs.yml` that triggers on release tags (`v*`), runs `./gradlew dokkaHtmlMultiModule`, and publishes output to `gh-pages` branch under `/api` via `peaceiris/actions-gh-pages@v4`

## Test plan

- [x] `./gradlew --no-daemon test :core:koverVerify spotlessCheck` passes (329 tasks, 0 failures)
- [x] `./gradlew tasks --group=documentation` confirms `dokkaHtmlMultiModule` task is registered
- [x] Gradle configuration resolves cleanly (no errors, one informational deprecation notice about V1)
- [ ] CI passes on PR

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)