### PR TITLE
fix: generate and commit initial BCV API dump files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
       - run: ./gradlew spotlessCheck
       - name: Check public API
         run: ./gradlew apiCheck
-        continue-on-error: true  # Non-blocking until first release
 
   build-ios:
     name: Build iOS

--- a/datastore-provider/api/android/datastore-provider.api
+++ b/datastore-provider/api/android/datastore-provider.api
@@ -1,0 +1,13 @@
+public final class dev/androidbroadcast/featured/datastore/DataStoreConfigValueProvider : dev/androidbroadcast/featured/LocalConfigValueProvider {
+	public static final field Companion Ldev/androidbroadcast/featured/datastore/DataStoreConfigValueProvider$Companion;
+	public static final field ID Ljava/lang/String;
+	public fun <init> (Landroidx/datastore/core/DataStore;)V
+	public fun get (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun observe (Ldev/androidbroadcast/featured/ConfigParam;)Lkotlinx/coroutines/flow/Flow;
+	public fun resetOverride (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun set (Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class dev/androidbroadcast/featured/datastore/DataStoreConfigValueProvider$Companion {
+}
+

--- a/datastore-provider/api/jvm/datastore-provider.api
+++ b/datastore-provider/api/jvm/datastore-provider.api
@@ -1,0 +1,13 @@
+public final class dev/androidbroadcast/featured/datastore/DataStoreConfigValueProvider : dev/androidbroadcast/featured/LocalConfigValueProvider {
+	public static final field Companion Ldev/androidbroadcast/featured/datastore/DataStoreConfigValueProvider$Companion;
+	public static final field ID Ljava/lang/String;
+	public fun <init> (Landroidx/datastore/core/DataStore;)V
+	public fun get (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun observe (Ldev/androidbroadcast/featured/ConfigParam;)Lkotlinx/coroutines/flow/Flow;
+	public fun resetOverride (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun set (Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class dev/androidbroadcast/featured/datastore/DataStoreConfigValueProvider$Companion {
+}
+

--- a/datastore-provider/build.gradle.kts
+++ b/datastore-provider/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.skie)
+    alias(libs.plugins.bcv)
     alias(libs.plugins.mavenPublish)
     alias(libs.plugins.dokka)
 }

--- a/featured-compose/api/android/featured-compose.api
+++ b/featured-compose/api/android/featured-compose.api
@@ -1,0 +1,18 @@
+public final class dev/androidbroadcast/featured/compose/ConfigValuesComposeExtensionsKt {
+	public static final fun collectAsState (Ldev/androidbroadcast/featured/ConfigValues;Ldev/androidbroadcast/featured/ConfigParam;Landroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public final class dev/androidbroadcast/featured/compose/FakeConfigValuesKt {
+	public static final fun fakeConfigValues (Lkotlin/jvm/functions/Function1;)Ldev/androidbroadcast/featured/ConfigValues;
+	public static synthetic fun fakeConfigValues$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/androidbroadcast/featured/ConfigValues;
+}
+
+public final class dev/androidbroadcast/featured/compose/FakeConfigValuesScope {
+	public static final field $stable I
+	public final fun set (Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;)V
+}
+
+public final class dev/androidbroadcast/featured/compose/LocalConfigValuesKt {
+	public static final fun getLocalConfigValues ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+

--- a/featured-compose/api/jvm/featured-compose.api
+++ b/featured-compose/api/jvm/featured-compose.api
@@ -1,0 +1,18 @@
+public final class dev/androidbroadcast/featured/compose/ConfigValuesComposeExtensionsKt {
+	public static final fun collectAsState (Ldev/androidbroadcast/featured/ConfigValues;Ldev/androidbroadcast/featured/ConfigParam;Landroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public final class dev/androidbroadcast/featured/compose/FakeConfigValuesKt {
+	public static final fun fakeConfigValues (Lkotlin/jvm/functions/Function1;)Ldev/androidbroadcast/featured/ConfigValues;
+	public static synthetic fun fakeConfigValues$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/androidbroadcast/featured/ConfigValues;
+}
+
+public final class dev/androidbroadcast/featured/compose/FakeConfigValuesScope {
+	public static final field $stable I
+	public final fun set (Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;)V
+}
+
+public final class dev/androidbroadcast/featured/compose/LocalConfigValuesKt {
+	public static final fun getLocalConfigValues ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+

--- a/featured-compose/build.gradle.kts
+++ b/featured-compose/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.bcv)
     alias(libs.plugins.mavenPublish)
     alias(libs.plugins.dokka)
 }

--- a/featured-debug-ui/api/android/featured-debug-ui.api
+++ b/featured-debug-ui/api/android/featured-debug-ui.api
@@ -1,0 +1,36 @@
+public final class dev/androidbroadcast/featured/debugui/ComposableSingletons$FeatureFlagsDebugScreenKt {
+	public static final field INSTANCE Ldev/androidbroadcast/featured/debugui/ComposableSingletons$FeatureFlagsDebugScreenKt;
+	public fun <init> ()V
+	public final fun getLambda$-64158089$featured_debug_ui_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-655542623$featured_debug_ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1477751099$featured_debug_ui_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class dev/androidbroadcast/featured/debugui/DebugFlagItem {
+	public static final field $stable I
+	public fun <init> (Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;Ljava/lang/Object;Ldev/androidbroadcast/featured/ConfigValue$Source;)V
+	public synthetic fun <init> (Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;Ljava/lang/Object;Ldev/androidbroadcast/featured/ConfigValue$Source;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/androidbroadcast/featured/ConfigParam;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Ljava/lang/Object;
+	public final fun component4 ()Ldev/androidbroadcast/featured/ConfigValue$Source;
+	public final fun copy (Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;Ljava/lang/Object;Ldev/androidbroadcast/featured/ConfigValue$Source;)Ldev/androidbroadcast/featured/debugui/DebugFlagItem;
+	public static synthetic fun copy$default (Ldev/androidbroadcast/featured/debugui/DebugFlagItem;Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;Ljava/lang/Object;Ldev/androidbroadcast/featured/ConfigValue$Source;ILjava/lang/Object;)Ldev/androidbroadcast/featured/debugui/DebugFlagItem;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCategory ()Ljava/lang/String;
+	public final fun getCurrentValue ()Ljava/lang/Object;
+	public final fun getDefaultValue ()Ljava/lang/Object;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getOverrideValue ()Ljava/lang/Object;
+	public final fun getParam ()Ldev/androidbroadcast/featured/ConfigParam;
+	public final fun getSource ()Ldev/androidbroadcast/featured/ConfigValue$Source;
+	public fun hashCode ()I
+	public final fun isOverridden ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/androidbroadcast/featured/debugui/FeatureFlagsDebugScreenKt {
+	public static final fun FeatureFlagsDebugScreen (Ldev/androidbroadcast/featured/ConfigValues;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/featured-debug-ui/api/jvm/featured-debug-ui.api
+++ b/featured-debug-ui/api/jvm/featured-debug-ui.api
@@ -1,0 +1,36 @@
+public final class dev/androidbroadcast/featured/debugui/ComposableSingletons$FeatureFlagsDebugScreenKt {
+	public static final field INSTANCE Ldev/androidbroadcast/featured/debugui/ComposableSingletons$FeatureFlagsDebugScreenKt;
+	public fun <init> ()V
+	public final fun getLambda$-64158089$featured_debug_ui ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-655542623$featured_debug_ui ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1477751099$featured_debug_ui ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class dev/androidbroadcast/featured/debugui/DebugFlagItem {
+	public static final field $stable I
+	public fun <init> (Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;Ljava/lang/Object;Ldev/androidbroadcast/featured/ConfigValue$Source;)V
+	public synthetic fun <init> (Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;Ljava/lang/Object;Ldev/androidbroadcast/featured/ConfigValue$Source;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/androidbroadcast/featured/ConfigParam;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Ljava/lang/Object;
+	public final fun component4 ()Ldev/androidbroadcast/featured/ConfigValue$Source;
+	public final fun copy (Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;Ljava/lang/Object;Ldev/androidbroadcast/featured/ConfigValue$Source;)Ldev/androidbroadcast/featured/debugui/DebugFlagItem;
+	public static synthetic fun copy$default (Ldev/androidbroadcast/featured/debugui/DebugFlagItem;Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;Ljava/lang/Object;Ldev/androidbroadcast/featured/ConfigValue$Source;ILjava/lang/Object;)Ldev/androidbroadcast/featured/debugui/DebugFlagItem;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCategory ()Ljava/lang/String;
+	public final fun getCurrentValue ()Ljava/lang/Object;
+	public final fun getDefaultValue ()Ljava/lang/Object;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getOverrideValue ()Ljava/lang/Object;
+	public final fun getParam ()Ldev/androidbroadcast/featured/ConfigParam;
+	public final fun getSource ()Ldev/androidbroadcast/featured/ConfigValue$Source;
+	public fun hashCode ()I
+	public final fun isOverridden ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/androidbroadcast/featured/debugui/FeatureFlagsDebugScreenKt {
+	public static final fun FeatureFlagsDebugScreen (Ldev/androidbroadcast/featured/ConfigValues;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/featured-debug-ui/build.gradle.kts
+++ b/featured-debug-ui/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.bcv)
     alias(libs.plugins.mavenPublish)
     alias(libs.plugins.dokka)
 }

--- a/featured-registry/api/android/featured-registry.api
+++ b/featured-registry/api/android/featured-registry.api
@@ -1,0 +1,6 @@
+public final class dev/androidbroadcast/featured/registry/FlagRegistry {
+	public static final field INSTANCE Ldev/androidbroadcast/featured/registry/FlagRegistry;
+	public final fun all ()Ljava/util/List;
+	public final fun register (Ldev/androidbroadcast/featured/ConfigParam;)V
+}
+

--- a/featured-registry/api/jvm/featured-registry.api
+++ b/featured-registry/api/jvm/featured-registry.api
@@ -1,0 +1,6 @@
+public final class dev/androidbroadcast/featured/registry/FlagRegistry {
+	public static final field INSTANCE Ldev/androidbroadcast/featured/registry/FlagRegistry;
+	public final fun all ()Ljava/util/List;
+	public final fun register (Ldev/androidbroadcast/featured/ConfigParam;)V
+}
+

--- a/featured-registry/build.gradle.kts
+++ b/featured-registry/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.bcv)
     alias(libs.plugins.mavenPublish)
     alias(libs.plugins.dokka)
 }

--- a/firebase-provider/api/firebase-provider.api
+++ b/firebase-provider/api/firebase-provider.api
@@ -1,0 +1,20 @@
+public abstract interface class dev/androidbroadcast/featured/firebase/Converter {
+	public abstract fun convert (Lcom/google/firebase/remoteconfig/FirebaseRemoteConfigValue;)Ljava/lang/Object;
+}
+
+public final class dev/androidbroadcast/featured/firebase/Converters {
+	public final fun contains (Lkotlin/reflect/KClass;)Z
+	public final fun get (Lkotlin/reflect/KClass;)Ldev/androidbroadcast/featured/firebase/Converter;
+	public final fun getValue (Lkotlin/reflect/KClass;)Ldev/androidbroadcast/featured/firebase/Converter;
+	public final fun set (Lkotlin/reflect/KClass;Ldev/androidbroadcast/featured/firebase/Converter;)V
+}
+
+public final class dev/androidbroadcast/featured/firebase/FirebaseConfigValueProvider : dev/androidbroadcast/featured/RemoteConfigValueProvider {
+	public fun <init> ()V
+	public fun <init> (Lcom/google/firebase/remoteconfig/FirebaseRemoteConfig;)V
+	public synthetic fun <init> (Lcom/google/firebase/remoteconfig/FirebaseRemoteConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun fetch (ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun get (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getConverters ()Ldev/androidbroadcast/featured/firebase/Converters;
+}
+

--- a/firebase-provider/build.gradle.kts
+++ b/firebase-provider/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)
+    alias(libs.plugins.bcv)
     alias(libs.plugins.mavenPublish)
     alias(libs.plugins.dokka)
 }

--- a/sharedpreferences-provider/api/sharedpreferences-provider.api
+++ b/sharedpreferences-provider/api/sharedpreferences-provider.api
@@ -1,0 +1,11 @@
+public final class dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfig : dev/androidbroadcast/featured/LocalConfigValueProvider {
+	public fun <init> (Landroid/content/SharedPreferences;Lkotlin/coroutines/CoroutineContext;)V
+	public synthetic fun <init> (Landroid/content/SharedPreferences;Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun get (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun observe (Ldev/androidbroadcast/featured/ConfigParam;)Lkotlinx/coroutines/flow/Flow;
+	public final fun remove (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun resetOverride (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun set (Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/sharedpreferences-provider/build.gradle.kts
+++ b/sharedpreferences-provider/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)
+    alias(libs.plugins.bcv)
     alias(libs.plugins.mavenPublish)
     alias(libs.plugins.dokka)
 }


### PR DESCRIPTION
## Summary

- Added `alias(libs.plugins.bcv)` to all publishable modules that were missing it: `featured-compose`, `featured-registry`, `featured-debug-ui`, `datastore-provider`, `sharedpreferences-provider`, `firebase-provider`
- Ran `./gradlew apiDump` to generate initial `.api` dump files for all modules (android + jvm targets for KMP modules, single `.api` for Android-only modules)
- Removed `continue-on-error: true` from the `apiCheck` CI step — binary compatibility is now enforced as a blocking gate

## Test plan

- [ ] `./gradlew apiCheck` passes locally (verified)
- [ ] `./gradlew test :core:koverVerify spotlessCheck` passes locally (verified)
- [ ] CI `apiCheck` step has no `continue-on-error` — it is blocking
- [ ] All `api/` directories contain valid `.api` dump files

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)