### PR TITLE
feat(core): add clear() to LocalConfigValueProvider interface

### DIFF
--- a/core/api/android/core.api
+++ b/core/api/android/core.api
@@ -51,6 +51,7 @@ public final class dev/androidbroadcast/featured/ConfigValues {
 	public fun <init> ()V
 	public fun <init> (Ldev/androidbroadcast/featured/LocalConfigValueProvider;Ldev/androidbroadcast/featured/RemoteConfigValueProvider;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Ldev/androidbroadcast/featured/LocalConfigValueProvider;Ldev/androidbroadcast/featured/RemoteConfigValueProvider;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun clearOverrides (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fetch (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getValue (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun initialize (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -70,7 +71,7 @@ public final class dev/androidbroadcast/featured/ConfigValuesExtensionsKt {
 
 public final class dev/androidbroadcast/featured/InMemoryConfigValueProvider : dev/androidbroadcast/featured/LocalConfigValueProvider {
 	public fun <init> ()V
-	public final fun clear ()V
+	public fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun get (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe (Ldev/androidbroadcast/featured/ConfigParam;)Lkotlinx/coroutines/flow/Flow;
 	public fun resetOverride (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -82,6 +83,7 @@ public abstract interface class dev/androidbroadcast/featured/InitializableConfi
 }
 
 public abstract interface class dev/androidbroadcast/featured/LocalConfigValueProvider : dev/androidbroadcast/featured/ConfigValueProvider {
+	public abstract fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun observe (Ldev/androidbroadcast/featured/ConfigParam;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun resetOverride (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun set (Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/api/jvm/core.api
+++ b/core/api/jvm/core.api
@@ -51,6 +51,7 @@ public final class dev/androidbroadcast/featured/ConfigValues {
 	public fun <init> ()V
 	public fun <init> (Ldev/androidbroadcast/featured/LocalConfigValueProvider;Ldev/androidbroadcast/featured/RemoteConfigValueProvider;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Ldev/androidbroadcast/featured/LocalConfigValueProvider;Ldev/androidbroadcast/featured/RemoteConfigValueProvider;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun clearOverrides (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fetch (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getValue (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun initialize (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -70,7 +71,7 @@ public final class dev/androidbroadcast/featured/ConfigValuesExtensionsKt {
 
 public final class dev/androidbroadcast/featured/InMemoryConfigValueProvider : dev/androidbroadcast/featured/LocalConfigValueProvider {
 	public fun <init> ()V
-	public final fun clear ()V
+	public fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun get (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe (Ldev/androidbroadcast/featured/ConfigParam;)Lkotlinx/coroutines/flow/Flow;
 	public fun resetOverride (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -82,6 +83,7 @@ public abstract interface class dev/androidbroadcast/featured/InitializableConfi
 }
 
 public abstract interface class dev/androidbroadcast/featured/LocalConfigValueProvider : dev/androidbroadcast/featured/ConfigValueProvider {
+	public abstract fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun observe (Ldev/androidbroadcast/featured/ConfigParam;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun resetOverride (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun set (Ldev/androidbroadcast/featured/ConfigParam;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValueProvider.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValueProvider.kt
@@ -57,6 +57,15 @@ public interface LocalConfigValueProvider : ConfigValueProvider {
     public suspend fun <T : Any> resetOverride(param: ConfigParam<T>)
 
     /**
+     * Removes all locally overridden values, resetting the provider to an empty state.
+     *
+     * After this call, [get] returns `null` for every parameter that was previously
+     * overridden, and [ConfigValues] falls back to the remote provider or
+     * [ConfigParam.defaultValue].
+     */
+    public suspend fun clear()
+
+    /**
      * Observes changes to the configuration value for the given parameter.
      * It emits the latest value immediately and then continues to emit updates
      * whenever the value changes locally.

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValues.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValues.kt
@@ -121,6 +121,16 @@ public class ConfigValues(
     }
 
     /**
+     * Removes all locally overridden values, resetting the local provider to an empty state.
+     *
+     * After this call, every [getValue] call falls back to the remote provider or
+     * [ConfigParam.defaultValue]. Has no effect when no local provider is configured.
+     */
+    public suspend fun clearOverrides() {
+        localProvider?.clear()
+    }
+
+    /**
      * Loads previously cached remote values into memory without performing a network fetch.
      *
      * Call this once at an appropriate moment during app startup — before any [getValue] calls

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProvider.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProvider.kt
@@ -77,7 +77,7 @@ public class InMemoryConfigValueProvider : LocalConfigValueProvider {
      * Unlike [resetOverride], this does **not** emit change signals. Callers that need
      * reactive updates after a bulk clear should call [resetOverride] per param instead.
      */
-    public fun clear() {
+    public override suspend fun clear() {
         storage = emptyMap()
     }
 

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ConfigValueProviderTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ConfigValueProviderTest.kt
@@ -27,6 +27,10 @@ class ConfigValueProviderTest {
             storage.remove(param.key)
         }
 
+        override suspend fun clear() {
+            storage.clear()
+        }
+
         override fun <T : Any> observe(param: ConfigParam<T>) = throw NotImplementedError()
     }
 
@@ -54,6 +58,21 @@ class ConfigValueProviderTest {
             lastActivateValue = activate
         }
     }
+
+    @Test
+    fun clear_removesAllLocalOverrides_soGetReturnsNullForEachParam() =
+        runTest {
+            val provider = TestLocalProvider()
+            val param1 = ConfigParam("key1", "default1")
+            val param2 = ConfigParam("key2", 0)
+            provider.set(param1, "value1")
+            provider.set(param2, 42)
+
+            provider.clear()
+
+            assertNull(provider.get(param1))
+            assertNull(provider.get(param2))
+        }
 
     @Test
     fun testLocalProviderBasicOperations() =

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ConfigValuesTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ConfigValuesTest.kt
@@ -297,4 +297,36 @@ class ConfigValuesTest {
                 cancelAndIgnoreRemainingEvents()
             }
         }
+
+    @Test
+    fun clearOverrides_removesAllLocalOverrides_andFallsBackToDefault() =
+        runTest {
+            val localProvider = InMemoryConfigValueProvider()
+            val configValues = ConfigValues(localProvider = localProvider)
+            val param1 = ConfigParam("flag1", "default1")
+            val param2 = ConfigParam("flag2", 0)
+            configValues.override(param1, "overridden1")
+            configValues.override(param2, 42)
+
+            configValues.clearOverrides()
+
+            val result1 = configValues.getValue(param1)
+            val result2 = configValues.getValue(param2)
+            assertEquals("default1", result1.value)
+            assertEquals(ConfigValue.Source.DEFAULT, result1.source)
+            assertEquals(0, result2.value)
+            assertEquals(ConfigValue.Source.DEFAULT, result2.source)
+        }
+
+    @Test
+    fun clearOverrides_withNoLocalProvider_doesNotThrow() =
+        runTest {
+            val configValues = ConfigValues(remoteProvider = MockRemoteProvider())
+            val param = ConfigParam("x", 0)
+
+            // Should be a no-op, not throw
+            configValues.clearOverrides()
+
+            assertEquals(0, configValues.getValue(param).value)
+        }
 }

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProviderTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProviderTest.kt
@@ -83,6 +83,34 @@ class InMemoryConfigValueProviderTest {
         }
 
     @Test
+    fun clear_removesAllStoredOverrides() =
+        runTest {
+            val provider = InMemoryConfigValueProvider()
+            val param1 = ConfigParam("key1", "default1")
+            val param2 = ConfigParam("key2", 99)
+            provider.set(param1, "value1")
+            provider.set(param2, 42)
+
+            provider.clear()
+
+            assertNull(provider.get(param1))
+            assertNull(provider.get(param2))
+        }
+
+    @Test
+    fun clear_asLocalConfigValueProvider_removesAllOverrides() =
+        runTest {
+            // Verify clear() is callable through the interface
+            val provider: LocalConfigValueProvider = InMemoryConfigValueProvider()
+            val param = ConfigParam("key", false)
+            provider.set(param, true)
+
+            provider.clear()
+
+            assertNull(provider.get(param))
+        }
+
+    @Test
     fun testObserveInitialValue() =
         runTest {
             val provider = InMemoryConfigValueProvider()

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ProviderErrorHandlingTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ProviderErrorHandlingTest.kt
@@ -31,6 +31,8 @@ class ProviderErrorHandlingTest {
 
         override suspend fun <T : Any> resetOverride(param: ConfigParam<T>) = Unit
 
+        override suspend fun clear() = Unit
+
         @Suppress("UNCHECKED_CAST")
         override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> = updates as Flow<ConfigValue<T>>
     }

--- a/datastore-provider/api/android/datastore-provider.api
+++ b/datastore-provider/api/android/datastore-provider.api
@@ -2,6 +2,7 @@ public final class dev/androidbroadcast/featured/datastore/DataStoreConfigValueP
 	public static final field Companion Ldev/androidbroadcast/featured/datastore/DataStoreConfigValueProvider$Companion;
 	public static final field ID Ljava/lang/String;
 	public fun <init> (Landroidx/datastore/core/DataStore;)V
+	public fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun get (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe (Ldev/androidbroadcast/featured/ConfigParam;)Lkotlinx/coroutines/flow/Flow;
 	public final fun registerConverter (Lkotlin/reflect/KClass;Ldev/androidbroadcast/featured/TypeConverter;)V

--- a/datastore-provider/api/jvm/datastore-provider.api
+++ b/datastore-provider/api/jvm/datastore-provider.api
@@ -2,6 +2,7 @@ public final class dev/androidbroadcast/featured/datastore/DataStoreConfigValueP
 	public static final field Companion Ldev/androidbroadcast/featured/datastore/DataStoreConfigValueProvider$Companion;
 	public static final field ID Ljava/lang/String;
 	public fun <init> (Landroidx/datastore/core/DataStore;)V
+	public fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun get (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe (Ldev/androidbroadcast/featured/ConfigParam;)Lkotlinx/coroutines/flow/Flow;
 	public final fun registerConverter (Lkotlin/reflect/KClass;Ldev/androidbroadcast/featured/TypeConverter;)V

--- a/datastore-provider/src/commonMain/kotlin/dev/androidbroadcast/featured/datastore/DataStoreConfigValueProvider.kt
+++ b/datastore-provider/src/commonMain/kotlin/dev/androidbroadcast/featured/datastore/DataStoreConfigValueProvider.kt
@@ -143,6 +143,17 @@ public class DataStoreConfigValueProvider(
     }
 
     /**
+     * Removes all persisted overrides by clearing the entire DataStore preferences file.
+     *
+     * After this call, [get] returns `null` for every parameter that was previously set,
+     * and [ConfigValues] falls back to the remote provider or [ConfigParam.defaultValue].
+     * Active [observe] flows will re-emit after the DataStore write completes.
+     */
+    override suspend fun clear() {
+        dataStore.edit { preferences -> preferences.clear() }
+    }
+
+    /**
      * Returns a [Flow] that emits a [ConfigValue] for [param] on every DataStore update.
      *
      * The flow emits immediately with the current persisted value (or [ConfigParam.defaultValue]

--- a/datastore-provider/src/commonTest/kotlin/dev/androidbroadcast/featured/datastore/DataStoreEnumTest.kt
+++ b/datastore-provider/src/commonTest/kotlin/dev/androidbroadcast/featured/datastore/DataStoreEnumTest.kt
@@ -63,4 +63,31 @@ class DataStoreEnumTest {
                 provider.set(param, CheckoutVariant.LEGACY)
             }
         }
+
+    @Test
+    fun clear_removesAllStoredValues_soGetReturnsNull() =
+        testScope.runTest {
+            val provider = createProvider()
+            val stringParam = ConfigParam("string_flag", "default")
+            val intParam = ConfigParam("int_flag", 0)
+            provider.set(stringParam, "value")
+            provider.set(intParam, 99)
+
+            provider.clear()
+
+            assertNull(provider.get(stringParam))
+            assertNull(provider.get(intParam))
+        }
+
+    @Test
+    fun clear_asLocalConfigValueProvider_removesAllValues() =
+        testScope.runTest {
+            val provider: dev.androidbroadcast.featured.LocalConfigValueProvider = createProvider()
+            val param = ConfigParam("flag", false)
+            provider.set(param, true)
+
+            provider.clear()
+
+            assertNull(provider.get(param))
+        }
 }

--- a/featured-compose/src/commonMain/kotlin/dev/androidbroadcast/featured/compose/FakeConfigValues.kt
+++ b/featured-compose/src/commonMain/kotlin/dev/androidbroadcast/featured/compose/FakeConfigValues.kt
@@ -73,6 +73,10 @@ private class FakeLocalConfigValueProvider(
         // no-op: fake provider does not support runtime mutations
     }
 
+    override suspend fun clear() {
+        // no-op: fake provider does not support runtime mutations
+    }
+
     @Suppress("UNCHECKED_CAST")
     override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> {
         val override = overrides[param.key] as? T

--- a/featured-debug-ui/src/commonTest/kotlin/dev/androidbroadcast/featured/debugui/BuildDebugItemsTest.kt
+++ b/featured-debug-ui/src/commonTest/kotlin/dev/androidbroadcast/featured/debugui/BuildDebugItemsTest.kt
@@ -28,6 +28,8 @@ class BuildDebugItemsTest {
 
                 override suspend fun <T : Any> resetOverride(param: ConfigParam<T>) = Unit
 
+                override suspend fun clear() = Unit
+
                 @Suppress("UNCHECKED_CAST")
                 override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
                     flowOf(ConfigValue(value = value as T, source = source))

--- a/sharedpreferences-provider/api/sharedpreferences-provider.api
+++ b/sharedpreferences-provider/api/sharedpreferences-provider.api
@@ -1,7 +1,7 @@
 public final class dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfig : dev/androidbroadcast/featured/LocalConfigValueProvider {
 	public fun <init> (Landroid/content/SharedPreferences;Lkotlin/coroutines/CoroutineContext;)V
 	public synthetic fun <init> (Landroid/content/SharedPreferences;Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun get (Ldev/androidbroadcast/featured/ConfigParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe (Ldev/androidbroadcast/featured/ConfigParam;)Lkotlinx/coroutines/flow/Flow;
 	public final fun registerConverter (Lkotlin/reflect/KClass;Ldev/androidbroadcast/featured/TypeConverter;)V

--- a/sharedpreferences-provider/src/main/kotlin/dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfig.kt
+++ b/sharedpreferences-provider/src/main/kotlin/dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfig.kt
@@ -144,9 +144,12 @@ public class SharedPreferencesProviderConfig(
         }
 
     /**
-     * Clears all feature flags from SharedPreferences.
+     * Removes all feature flags from SharedPreferences.
+     *
+     * After this call, [get] returns `null` for every parameter that was previously set,
+     * and [ConfigValues] falls back to the remote provider or [ConfigParam.defaultValue].
      */
-    public suspend fun clear(): Unit =
+    public override suspend fun clear(): Unit =
         withContext(context) {
             sharedPreferences.edit(commit = true) {
                 clear()

--- a/sharedpreferences-provider/src/test/kotlin/dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfigTest.kt
+++ b/sharedpreferences-provider/src/test/kotlin/dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfigTest.kt
@@ -369,4 +369,17 @@ class SharedPreferencesProviderConfigTest {
                 assertTrue(e.message!!.contains("Unsupported type"))
             }
         }
+
+    @Test
+    fun `clear via LocalConfigValueProvider interface removes all values`() =
+        runTest {
+            val localProvider: dev.androidbroadcast.featured.LocalConfigValueProvider = provider
+            localProvider.set(stringParam, "value1")
+            localProvider.set(intParam, 99)
+
+            localProvider.clear()
+
+            assertNull(localProvider.get(stringParam))
+            assertNull(localProvider.get(intParam))
+        }
 }


### PR DESCRIPTION
## Summary

- Adds `suspend fun clear()` to `LocalConfigValueProvider` interface so all providers support bulk removal of overrides
- `InMemoryConfigValueProvider.clear()` promoted from non-suspend `public fun` to `override suspend fun`
- `DataStoreConfigValueProvider` gains `clear()` via `dataStore.edit { preferences.clear() }`
- `SharedPreferencesProviderConfig.clear()` gains `override` modifier (method already existed)
- Adds `ConfigValues.clearOverrides()` as a convenience wrapper delegating to the local provider
- All test stubs across modules updated; new tests verify `clear()` in every provider and through the `LocalConfigValueProvider` interface
- BCV dumps updated via `./gradlew apiDump`

Closes #48

## Test plan

- [x] `./gradlew test` — all tests pass (352 tasks)
- [x] `./gradlew :core:koverVerify` — ≥90% line coverage maintained
- [x] `./gradlew spotlessCheck` — no style violations
- [x] `./gradlew apiCheck` — BCV dumps match generated API

🤖 Generated with [Claude Code](https://claude.com/claude-code)