### PR TITLE
fix(firebase-provider): correct namespace typo

### DIFF
--- a/firebase-provider/build.gradle.kts
+++ b/firebase-provider/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 android {
-    namespace = "dev.androidbroadcast.featured.fireabase"
+    namespace = "dev.androidbroadcast.featured.firebase"
     compileSdk =
         libs.versions.android.compileSdk
             .get()


### PR DESCRIPTION
Closes #32

## Summary
- Corrected typo in `firebase-provider/build.gradle.kts`: `fireabase` → `firebase`
- Verified no other files reference the old incorrect namespace
- Build passes with corrected namespace

## Test plan
- [x] `./gradlew :firebase-provider:assembleDebug` builds successfully
- [x] `./gradlew test :core:koverVerify spotlessCheck` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)