### PR TITLE
fix: add consumer ProGuard rules to firebase-provider and sharedprefs-provider

### DIFF
--- a/firebase-provider/consumer-rules.pro
+++ b/firebase-provider/consumer-rules.pro
@@ -1,0 +1,8 @@
+# Consumer ProGuard rules for firebase-provider
+# These rules are applied to consuming apps automatically.
+
+# Keep Firebase Remote Config classes used by this library
+-keepnames class com.google.firebase.remoteconfig.** { *; }
+
+# Keep Featured Firebase provider classes
+-keepnames class dev.androidbroadcast.featured.firebase.** { *; }

--- a/sharedpreferences-provider/consumer-rules.pro
+++ b/sharedpreferences-provider/consumer-rules.pro
@@ -1,2 +1,5 @@
-# Consumer proguard rules for sharedpreferences-provider
+# Consumer ProGuard rules for sharedpreferences-provider
+# These rules are applied to consuming apps automatically.
 
+# Keep SharedPreferences implementations used by this library
+-keepclassmembers class * implements android.content.SharedPreferences { *; }


### PR DESCRIPTION
## Summary

- Populates `firebase-provider/consumer-rules.pro` with rules to keep Firebase Remote Config classes and the Featured Firebase provider package from being obfuscated
- Populates `sharedpreferences-provider/consumer-rules.pro` with rules to keep SharedPreferences implementors' class members intact
- Both `assembleRelease` builds verified successfully; all unit tests and spotless checks pass

Closes #40