### PR TITLE
test(datastore-provider): add full test suite

### DIFF
--- a/datastore-provider/build.gradle.kts
+++ b/datastore-provider/build.gradle.kts
@@ -50,6 +50,16 @@ kotlin {
             dependencies {
                 implementation(libs.kotlin.test)
                 implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.turbine)
+            }
+        }
+
+        @Suppress("unused")
+        val jvmTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.turbine)
             }
         }
     }

--- a/datastore-provider/src/commonTest/kotlin/dev/androidbroadcast/featured/datastore/DataStoreConfigValueProviderTest.kt
+++ b/datastore-provider/src/commonTest/kotlin/dev/androidbroadcast/featured/datastore/DataStoreConfigValueProviderTest.kt
@@ -1,0 +1,285 @@
+package dev.androidbroadcast.featured.datastore
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import app.cash.turbine.test
+import dev.androidbroadcast.featured.ConfigParam
+import dev.androidbroadcast.featured.ConfigValue
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class DataStoreConfigValueProviderTest {
+    private val testScope = TestScope()
+
+    private fun createProvider(name: String = "test_${System.currentTimeMillis()}"): DataStoreConfigValueProvider {
+        val dataStore =
+            PreferenceDataStoreFactory.createWithPath(
+                scope = testScope,
+                produceFile = { "$name.preferences_pb".toPath() },
+            )
+        return DataStoreConfigValueProvider(dataStore)
+    }
+
+    // --- get() ---
+
+    @Test
+    fun get_returnsNull_whenKeyNotSet() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("missing_key", "default")
+
+            assertNull(provider.get(param))
+        }
+
+    @Test
+    fun get_returnsStoredValue_afterSet() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("string_key", "default")
+
+            provider.set(param, "hello")
+            val result = provider.get(param)
+
+            assertNotNull(result)
+            assertEquals("hello", result.value)
+        }
+
+    @Test
+    fun get_returnsSourceLocal_whenValueSet() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("source_check", false)
+
+            provider.set(param, true)
+            val result = provider.get(param)
+
+            assertNotNull(result)
+            assertEquals(ConfigValue.Source.LOCAL, result.source)
+        }
+
+    // --- Type round-trips ---
+
+    @Test
+    fun roundTrip_string() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("str", "")
+
+            provider.set(param, "hello world")
+
+            assertEquals("hello world", provider.get(param)?.value)
+        }
+
+    @Test
+    fun roundTrip_int() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("int", 0)
+
+            provider.set(param, Int.MAX_VALUE)
+
+            assertEquals(Int.MAX_VALUE, provider.get(param)?.value)
+        }
+
+    @Test
+    fun roundTrip_long() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("long", 0L)
+
+            provider.set(param, Long.MAX_VALUE)
+
+            assertEquals(Long.MAX_VALUE, provider.get(param)?.value)
+        }
+
+    @Test
+    fun roundTrip_float() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("float", 0f)
+
+            provider.set(param, 3.14f)
+
+            val result = provider.get(param)
+            assertNotNull(result)
+            assertEquals(3.14f, result.value, 0.0001f)
+        }
+
+    @Test
+    fun roundTrip_double() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("double", 0.0)
+
+            provider.set(param, 2.718281828)
+
+            val result = provider.get(param)
+            assertNotNull(result)
+            assertEquals(2.718281828, result.value, 0.000000001)
+        }
+
+    @Test
+    fun roundTrip_boolean_true() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("bool_true", false)
+
+            provider.set(param, true)
+
+            assertEquals(true, provider.get(param)?.value)
+        }
+
+    @Test
+    fun roundTrip_boolean_false() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("bool_false", true)
+
+            provider.set(param, false)
+
+            assertEquals(false, provider.get(param)?.value)
+        }
+
+    // --- Unsupported type ---
+
+    @Test
+    fun set_throwsIllegalArgumentException_forUnsupportedType() =
+        testScope.runTest {
+            val provider = createProvider()
+
+            data class Unsupported(
+                val x: Int,
+            )
+
+            val param = ConfigParam("bad_type", Unsupported(1))
+
+            assertFailsWith<IllegalArgumentException> {
+                provider.set(param, Unsupported(2))
+            }
+        }
+
+    @Test
+    fun get_throwsIllegalArgumentException_forUnsupportedType() =
+        testScope.runTest {
+            val provider = createProvider()
+
+            data class Unsupported(
+                val x: Int,
+            )
+
+            val param = ConfigParam("bad_type_get", Unsupported(1))
+
+            assertFailsWith<IllegalArgumentException> {
+                provider.get(param)
+            }
+        }
+
+    // --- observe() — first emission only (safe on all platforms) ---
+
+    @Test
+    fun observe_emitsCurrentValue_onSubscription() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("obs_key", "default")
+            provider.set(param, "initial")
+
+            provider.observe(param).test {
+                val emission = awaitItem()
+                assertEquals("initial", emission.value)
+                assertEquals(ConfigValue.Source.LOCAL, emission.source)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun observe_emitsDefault_whenNotSet() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("obs_default", "my_default")
+
+            provider.observe(param).test {
+                val emission = awaitItem()
+                assertEquals("my_default", emission.value)
+                assertEquals(ConfigValue.Source.DEFAULT, emission.source)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // --- resetOverride ---
+
+    @Test
+    fun resetOverride_makesGetReturnNull() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("reset_key", "default")
+
+            provider.set(param, "set_value")
+            assertNotNull(provider.get(param))
+
+            provider.resetOverride(param)
+
+            assertNull(provider.get(param))
+        }
+
+    // --- clear ---
+
+    @Test
+    fun clear_removesAllValues() =
+        testScope.runTest {
+            val provider = createProvider()
+            val stringParam = ConfigParam("clear_str", "default")
+            val intParam = ConfigParam("clear_int", 0)
+            val boolParam = ConfigParam("clear_bool", false)
+
+            provider.set(stringParam, "value")
+            provider.set(intParam, 42)
+            provider.set(boolParam, true)
+
+            provider.clear()
+
+            assertNull(provider.get(stringParam))
+            assertNull(provider.get(intParam))
+            assertNull(provider.get(boolParam))
+        }
+
+    // --- Persistence ---
+
+    @Test
+    fun value_persistsAfterOtherKeyReset() =
+        testScope.runTest {
+            val provider = createProvider()
+            val persistedParam = ConfigParam("persistent_key", "default")
+            val otherParam = ConfigParam("other_key", "other_default")
+
+            provider.set(persistedParam, "persisted_value")
+            provider.set(otherParam, "other_value")
+
+            provider.resetOverride(otherParam)
+
+            val result = provider.get(persistedParam)
+            assertNotNull(result)
+            assertEquals("persisted_value", result.value)
+            assertEquals(ConfigValue.Source.LOCAL, result.source)
+        }
+
+    @Test
+    fun value_isReadableAfterMultipleSets() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("multi_set_key", "default")
+
+            provider.set(param, "first")
+            provider.set(param, "second")
+            provider.set(param, "third")
+
+            val result = provider.get(param)
+            assertNotNull(result)
+            assertEquals("third", result.value)
+            assertEquals(ConfigValue.Source.LOCAL, result.source)
+        }
+}

--- a/datastore-provider/src/jvmTest/kotlin/dev/androidbroadcast/featured/datastore/DataStoreConfigValueProviderFlowTest.kt
+++ b/datastore-provider/src/jvmTest/kotlin/dev/androidbroadcast/featured/datastore/DataStoreConfigValueProviderFlowTest.kt
@@ -1,0 +1,124 @@
+package dev.androidbroadcast.featured.datastore
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import app.cash.turbine.test
+import dev.androidbroadcast.featured.ConfigParam
+import dev.androidbroadcast.featured.ConfigValue
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * JVM-only tests for reactive [DataStoreConfigValueProvider.observe] behaviour and concurrent
+ * write scenarios. These tests rely on DataStore's file-based write serialisation which is
+ * not compatible with the Robolectric file-rename restrictions used in Android unit tests.
+ */
+class DataStoreConfigValueProviderFlowTest {
+    private val testScope = TestScope()
+
+    private fun createProvider(name: String = "flow_test_${System.currentTimeMillis()}"): DataStoreConfigValueProvider {
+        val dataStore =
+            PreferenceDataStoreFactory.createWithPath(
+                scope = testScope,
+                produceFile = { "$name.preferences_pb".toPath() },
+            )
+        return DataStoreConfigValueProvider(dataStore)
+    }
+
+    // --- observe() reactive emissions ---
+
+    @Test
+    fun observe_emitsNewValue_afterSet() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("obs_update", "default")
+
+            provider.observe(param).test {
+                awaitItem() // initial default emission
+
+                provider.set(param, "updated")
+
+                val updated = awaitItem()
+                assertEquals("updated", updated.value)
+                assertEquals(ConfigValue.Source.LOCAL, updated.source)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun observe_emitsMultipleUpdates_inOrder() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("obs_multi", "default")
+
+            provider.observe(param).test {
+                awaitItem() // default
+
+                provider.set(param, "first")
+                assertEquals("first", awaitItem().value)
+
+                provider.set(param, "second")
+                assertEquals("second", awaitItem().value)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun resetOverride_causesObserveToEmitDefault() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("reset_obs", "fallback")
+            provider.set(param, "stored")
+
+            provider.observe(param).test {
+                awaitItem() // stored value
+
+                provider.resetOverride(param)
+
+                val afterReset = awaitItem()
+                assertEquals("fallback", afterReset.value)
+                assertEquals(ConfigValue.Source.DEFAULT, afterReset.source)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // --- Concurrent reads and writes ---
+
+    @Test
+    fun concurrentWrites_doNotCorruptData() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("concurrent_key", 0)
+
+            // DataStore serialises writes internally via its write actor
+            val writes =
+                (1..10).map { i ->
+                    async { provider.set(param, i) }
+                }
+            writes.awaitAll()
+
+            // Final value must be one of 1..10 and source must be LOCAL
+            val result = provider.get(param)
+            assertNotNull(result)
+            assertEquals(ConfigValue.Source.LOCAL, result.source)
+        }
+
+    @Test
+    fun concurrentReadsAndWrites_doNotThrow() =
+        testScope.runTest {
+            val provider = createProvider()
+            val param = ConfigParam("rw_concurrent", "initial")
+            provider.set(param, "initial")
+
+            val readers = (1..5).map { async { provider.get(param) } }
+            val writers = (1..5).map { i -> async { provider.set(param, "value_$i") } }
+            (readers + writers).awaitAll()
+            // No exception = pass
+        }
+}


### PR DESCRIPTION
## Summary

- Adds 17 cross-platform tests in `commonTest` covering all `DataStoreConfigValueProvider` behaviours: `get`/`set`, all 6 built-in type round-trips (String, Int, Long, Float, Double, Boolean), unsupported-type `IllegalArgumentException`, `observe` first-emission (current value and default), `resetOverride`, `clear`, and persistence across multiple sequential writes
- Adds 5 JVM-only tests in `jvmTest` for reactive `observe`-after-mutation flows and concurrent read/write scenarios (isolated to JVM because Robolectric's file-rename restriction makes these unreliable as Android unit tests)
- Adds `turbine` and a `jvmTest` source set to `datastore-provider/build.gradle.kts`

Closes #34

## Test plan

- [ ] `./gradlew :datastore-provider:jvmTest` — 22 tests pass (17 common + 5 JVM-only)
- [ ] `./gradlew :datastore-provider:test` — 34 Android unit tests pass (17 common × debug + release)
- [ ] `./gradlew spotlessCheck` — no formatting violations
- [ ] `./gradlew :core:koverVerify` — core coverage threshold still met

🤖 Generated with [Claude Code](https://claude.com/claude-code)