### PR TITLE
test(gradle-plugin): add xcconfig and const val generation tests

### DIFF
--- a/featured-gradle-plugin/src/test/kotlin/dev/androidbroadcast/featured/gradle/LocalFlagScannerTest.kt
+++ b/featured-gradle-plugin/src/test/kotlin/dev/androidbroadcast/featured/gradle/LocalFlagScannerTest.kt
@@ -219,6 +219,50 @@ class LocalFlagScannerTest {
     }
 
     @Test
+    fun `scanner ignores RemoteFlag-annotated ConfigParam - not included in xcconfig or const val generation`() {
+        // @RemoteFlag declarations must never appear in LocalFlagEntry results;
+        // XcconfigGenerator and IosConstValGenerator only receive LocalFlagEntry lists,
+        // so excluding @RemoteFlag at scan time guarantees nothing is generated for them.
+        val source =
+            """
+            package com.example
+            @RemoteFlag
+            val remoteFeature = ConfigParam("remote_feature", false)
+            @LocalFlag
+            val localFeature = ConfigParam("local_feature", false)
+            """.trimIndent()
+
+        val result = LocalFlagScanner.scan(source, moduleName = "app")
+
+        assertEquals(1, result.size, "Expected only @LocalFlag entry, not @RemoteFlag")
+        assertEquals("local_feature", result[0].key)
+    }
+
+    @Test
+    fun `scanner ignores RemoteFlag-only source - generators produce no iOS output`() {
+        val source =
+            """
+            package com.example
+            @RemoteFlag
+            val newCheckoutFlow = ConfigParam("new_checkout_flow", false)
+            @RemoteFlag
+            val darkMode = ConfigParam("dark_mode", true)
+            """.trimIndent()
+
+        val entries = LocalFlagScanner.scan(source, moduleName = "app")
+
+        assertTrue(entries.isEmpty(), "Expected no entries from @RemoteFlag-only source")
+        assertTrue(
+            XcconfigGenerator.generate(entries).isBlank(),
+            "Expected no xcconfig output for @RemoteFlag flags",
+        )
+        assertTrue(
+            IosConstValGenerator.generate(entries).isBlank(),
+            "Expected no const val output for @RemoteFlag flags",
+        )
+    }
+
+    @Test
     fun `LocalFlagEntry data class equality works correctly`() {
         val entry1 = LocalFlagEntry("k", "v", "String", "mod")
         val entry2 = LocalFlagEntry("k", "v", "String", "mod")


### PR DESCRIPTION
## Summary

- Adds two tests to `LocalFlagScannerTest` covering the `@RemoteFlag` exclusion requirement from issue #29
- Confirms `@RemoteFlag`-annotated `ConfigParam` declarations are never included in `LocalFlagEntry` results, so neither `XcconfigGenerator` nor `IosConstValGenerator` produces any iOS output for them
- All other issue #29 acceptance criteria (`@LocalFlag false → DISABLE_X`, `@LocalFlag true → no condition`, `new_checkout_flow → DISABLE_NEW_CHECKOUT_FLOW`, `const val` output format) were already covered by existing tests in `XcconfigGeneratorTest` and `IosConstValGeneratorTest`

## Test plan

- [x] `./gradlew --no-daemon :featured-gradle-plugin:test` passes (BUILD SUCCESSFUL, 0 failures)
- [x] New tests: `scanner ignores RemoteFlag-annotated ConfigParam` and `scanner ignores RemoteFlag-only source - generators produce no iOS output`
- [x] No duplicate tests added

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)