### PR TITLE
docs: enhance platform integration guides (Android, iOS, JVM)

### DIFF
--- a/docs/guides/android.md
+++ b/docs/guides/android.md
@@ -1,45 +1,157 @@
-# Android Guide
+# Android Integration Guide
 
-This guide covers Android-specific integration: reading flags reactively, using Compose extensions, and the debug UI.
+This guide walks you through integrating Featured into an Android project from scratch — from adding Gradle dependencies to using flags in a ViewModel with Compose and Firebase Remote Config.
 
-## Reading flags
+## 1. Add Gradle dependencies
 
-### One-shot read
+Apply the Featured Gradle plugin and declare the artifacts you need. The BOM manages all module versions from a single place.
 
-```kotlin
-val configValue: ConfigValue<Boolean> = configValues.getValue(FeatureFlags.newCheckout)
-if (configValue.value) {
-    // feature is active
+```kotlin title="build.gradle.kts"
+plugins {
+    id("dev.androidbroadcast.featured") version "<version>"
+}
+
+dependencies {
+    implementation(platform("dev.androidbroadcast.featured:featured-bom:<version>"))
+
+    // Core runtime — always required
+    implementation("dev.androidbroadcast.featured:core")
+
+    // Local persistence — pick one (or both)
+    implementation("dev.androidbroadcast.featured:datastore-provider")
+    implementation("dev.androidbroadcast.featured:sharedpreferences-provider")
+
+    // Remote config
+    implementation("dev.androidbroadcast.featured:firebase-provider")
+
+    // Compose extensions
+    implementation("dev.androidbroadcast.featured:featured-compose")
+
+    // Debug UI — debug builds only
+    debugImplementation("dev.androidbroadcast.featured:featured-registry")
+    debugImplementation("dev.androidbroadcast.featured:featured-debug-ui")
 }
 ```
 
-### Reactive observation (Flow)
+!!! note
+    The Gradle plugin ID is `dev.androidbroadcast.featured`. It generates ProGuard / R8 rules and xcconfig files automatically when you build.
+
+## 2. Declare flags
+
+```kotlin title="shared/src/commonMain/kotlin/com/example/FeatureFlags.kt"
+import dev.androidbroadcast.featured.ConfigParam
+import dev.androidbroadcast.featured.LocalFlag
+
+object FeatureFlags {
+    @LocalFlag
+    val newCheckout = ConfigParam<Boolean>(
+        key = "new_checkout",
+        defaultValue = false,
+        description = "Enable the new checkout flow",
+    )
+
+    @LocalFlag
+    val maxCartItems = ConfigParam<Int>(
+        key = "max_cart_items",
+        defaultValue = 10,
+    )
+}
+```
+
+Annotate flags with `@LocalFlag` so the Gradle plugin can scan them for code generation (ProGuard rules, xcconfig).
+
+## 3. Initialize `ConfigValues` in `Application.onCreate`
+
+Create a single `ConfigValues` instance and call `initialize()` before the app serves any screen. `initialize()` triggers the remote provider's activation step (for Firebase: activates fetched values).
+
+### With DataStore (recommended)
+
+```kotlin title="MyApplication.kt"
+import androidx.datastore.preferences.preferencesDataStore
+import dev.androidbroadcast.featured.ConfigValues
+import dev.androidbroadcast.featured.datastore.DataStoreConfigValueProvider
+import dev.androidbroadcast.featured.firebase.FirebaseConfigValueProvider
+
+val Context.featureFlagDataStore by preferencesDataStore(name = "feature_flags")
+
+class MyApplication : Application() {
+
+    lateinit var configValues: ConfigValues
+
+    override fun onCreate() {
+        super.onCreate()
+
+        val localProvider = DataStoreConfigValueProvider(featureFlagDataStore)
+        val remoteProvider = FirebaseConfigValueProvider()
+
+        configValues = ConfigValues(
+            localProvider = localProvider,
+            remoteProvider = remoteProvider,
+        )
+
+        // Activate previously fetched remote values and trigger a background fetch
+        lifecycleScope.launch {
+            configValues.initialize()
+            configValues.fetch()
+        }
+    }
+}
+```
+
+### With SharedPreferences
 
 ```kotlin
-// Emits immediately with the current value, then on every change
-configValues.observe(FeatureFlags.newCheckout)
-    .collect { configValue ->
-        println("new_checkout = ${configValue.value} (source: ${configValue.source})")
-    }
+import android.content.Context
+import dev.androidbroadcast.featured.ConfigValues
+import dev.androidbroadcast.featured.sharedpreferences.SharedPreferencesProviderConfig
 
-// Convenience: emit only the raw value, not the ConfigValue wrapper
-configValues.observeValue(FeatureFlags.newCheckout)
-    .collect { isEnabled: Boolean -> /* … */ }
+val prefs = context.getSharedPreferences("feature_flags", Context.MODE_PRIVATE)
+val localProvider = SharedPreferencesProviderConfig(prefs)
 
-// Convert to StateFlow
-val isEnabled: StateFlow<Boolean> = configValues.asStateFlow(
+val configValues = ConfigValues(localProvider = localProvider)
+```
+
+## 4. Use in ViewModel with `observe`
+
+Expose flag state as `StateFlow` so Compose (or view-based UIs) can collect it:
+
+```kotlin
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.androidbroadcast.featured.ConfigValues
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+class CheckoutViewModel(
+    private val configValues: ConfigValues,
+) : ViewModel() {
+
+    // StateFlow of the raw Boolean — reacts to both local and remote changes
+    val isNewCheckoutEnabled: StateFlow<Boolean> =
+        configValues.observe(FeatureFlags.newCheckout)
+            .map { it.value }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = FeatureFlags.newCheckout.defaultValue,
+            )
+}
+```
+
+Or use the built-in `asStateFlow` extension:
+
+```kotlin
+val isNewCheckoutEnabled: StateFlow<Boolean> = configValues.asStateFlow(
     param = FeatureFlags.newCheckout,
     scope = viewModelScope,
 )
 ```
 
-## Compose integration
+## 5. Compose integration
 
-Add the `featured-compose` artifact to your dependencies:
-
-```kotlin
-implementation("dev.androidbroadcast.featured:featured-compose")
-```
+Add the `featured-compose` artifact (already listed in step 1).
 
 ### Collecting flag state in a Composable
 
@@ -73,30 +185,54 @@ fun SomeDeepComponent() {
 }
 ```
 
-## Debug UI
+## 6. Add Firebase Remote Config provider
 
-`featured-debug-ui` provides a ready-made Compose screen that lists all registered flags with their current values and sources, and lets you toggle or override them at runtime.
-
-Add the debug artifacts only to debug builds:
+`FirebaseConfigValueProvider` wraps the Firebase SDK. Add the dependency (step 1) and pass it as `remoteProvider`:
 
 ```kotlin
-debugImplementation("dev.androidbroadcast.featured:featured-registry")
-debugImplementation("dev.androidbroadcast.featured:featured-debug-ui")
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import dev.androidbroadcast.featured.firebase.FirebaseConfigValueProvider
+
+// Use the default singleton (recommended)
+val remoteProvider = FirebaseConfigValueProvider()
+
+// Or supply a custom instance with non-default fetch interval
+val remoteConfig = FirebaseRemoteConfig.getInstance().also { config ->
+    config.setConfigSettingsAsync(
+        com.google.firebase.remoteconfig.remoteConfigSettings {
+            minimumFetchIntervalInSeconds = 3600
+        }
+    )
+}
+val remoteProvider = FirebaseConfigValueProvider(remoteConfig)
+
+val configValues = ConfigValues(
+    localProvider = localProvider,
+    remoteProvider = remoteProvider,
+)
 ```
 
-### 1. Register flags
+After `configValues.initialize()`, remote values fetched during the previous session become active. Call `configValues.fetch()` to trigger a fresh fetch and activate the result.
 
-Register each `ConfigParam` in the `FlagRegistry` so the debug screen can discover them:
+## 7. Debug UI — flag override screen
+
+`featured-debug-ui` ships a Compose screen that lists every registered flag with its current value and source, and lets you toggle or override values at runtime.
+
+Add debug artifacts only to debug builds (step 1 already shows `debugImplementation`).
+
+### Register flags
 
 ```kotlin
 import dev.androidbroadcast.featured.registry.FlagRegistry
 
-// Call once on app start (e.g., in Application.onCreate or your DI module)
-FlagRegistry.register(FeatureFlags.newCheckout)
-FlagRegistry.register(FeatureFlags.maxCartItems)
+// Call once in Application.onCreate (or your DI module) — debug builds only
+if (BuildConfig.DEBUG) {
+    FlagRegistry.register(FeatureFlags.newCheckout)
+    FlagRegistry.register(FeatureFlags.maxCartItems)
+}
 ```
 
-### 2. Show the debug screen
+### Show the debug screen
 
 ```kotlin
 import dev.androidbroadcast.featured.debugui.FeatureFlagsDebugScreen
@@ -107,9 +243,11 @@ fun DebugMenuScreen(configValues: ConfigValues) {
 }
 ```
 
-## Release build optimization — R8 rules
+Navigate to this screen from your in-app debug menu (a drawer, a shake gesture, or a long-press on the app icon shortcut).
 
-The Gradle plugin generates ProGuard / R8 `-assumevalues` rules for every `@LocalFlag`-annotated `ConfigParam<Boolean>` with `defaultValue = false`. These rules instruct R8 to treat the flag as a constant `false` at shrink time, so all code guarded by `if (flag.value)` is removed from the release APK.
+## 8. ProGuard / R8 setup
+
+The Gradle plugin generates `-assumevalues` rules for every `@LocalFlag`-annotated `ConfigParam<Boolean>` with `defaultValue = false`. These rules instruct R8 to treat the flag as a compile-time constant `false`, removing all guarded code from release APKs.
 
 The task runs automatically when you build a release variant. To run it manually:
 
@@ -129,4 +267,41 @@ configValues.override(FeatureFlags.newCheckout, true)
 
 // Revert to the provider's stored or default value
 configValues.resetOverride(FeatureFlags.newCheckout)
+
+// Clear all local overrides
+configValues.clearOverrides()
 ```
+
+## Reading flags
+
+### One-shot read
+
+```kotlin
+val configValue: ConfigValue<Boolean> = configValues.getValue(FeatureFlags.newCheckout)
+if (configValue.value) {
+    // feature is active
+}
+val source = configValue.source // DEFAULT, LOCAL, or REMOTE
+```
+
+### Reactive observation (Flow)
+
+```kotlin
+// Emits immediately with the current value, then on every change
+configValues.observe(FeatureFlags.newCheckout)
+    .collect { configValue ->
+        println("new_checkout = ${configValue.value} (source: ${configValue.source})")
+    }
+
+// Convenience: emit only the raw value, not the ConfigValue wrapper
+configValues.observe(FeatureFlags.newCheckout)
+    .map { it.value }
+    .collect { isEnabled: Boolean -> /* … */ }
+```
+
+## Next steps
+
+- [iOS guide](ios.md) — Swift interop and dead-code elimination
+- [JVM guide](jvm.md) — server and desktop integration
+- [Providers](providers.md) — all built-in providers in detail
+- [Best practices](best-practices.md) — multi-module setup and testing

--- a/docs/guides/ios.md
+++ b/docs/guides/ios.md
@@ -1,8 +1,8 @@
-# iOS Guide
+# iOS Integration Guide
 
 Featured exposes its Kotlin API to Swift via [SKIE](https://skie.touchlab.co/), which bridges coroutines, sealed classes, and default arguments automatically.
 
-## Swift Package Manager setup
+## 1. Swift Package Manager setup
 
 Add the package in Xcode (**File › Add Package Dependencies**) or in `Package.swift`:
 
@@ -24,46 +24,156 @@ Then add `FeaturedCore` as a target dependency:
 )
 ```
 
-## Reading flags in Swift
+## 2. Declare flags in Kotlin (shared module)
 
-The `FeatureFlags` Swift class wraps `CoreConfigValues` (the KMP-exported type). Define your flags as `FeatureFlag` values that reference the shared `CoreConfigParam` exported from Kotlin:
+Flags live in the shared Kotlin module and are exported to Swift. Annotate them with `@LocalFlag` so the Gradle plugin can scan them:
+
+```kotlin title="shared/src/commonMain/kotlin/com/example/FeatureFlags.kt"
+import dev.androidbroadcast.featured.ConfigParam
+import dev.androidbroadcast.featured.LocalFlag
+
+object FeatureFlags {
+    @LocalFlag
+    val newCheckout = ConfigParam<Boolean>(
+        key = "new_checkout",
+        defaultValue = false,
+        description = "Enable the new checkout flow",
+    )
+}
+```
+
+## 3. Initialize `ConfigValues` in Swift
+
+Call `initialize()` at app launch (before serving any screen) to activate values fetched during the previous session. Then trigger a background fetch so the next launch sees fresh values.
 
 ```swift
 import FeaturedCore
 
-// Map a Kotlin ConfigParam to a Swift FeatureFlag
-let newCheckoutFlag = FeatureFlag<Bool>(
-    param: CoreFeatureFlagsCompanion().newCheckout,
-    defaultValue: false
-)
+@main
+struct MyApp: App {
+    @StateObject private var appState = AppState()
 
-let featureFlags = FeatureFlags(configValues)
-
-// Async read
-let isEnabled = try await featureFlags.value(of: newCheckoutFlag)
-
-// AsyncStream — use in a Task or async for-await loop
-for await value in featureFlags.stream(of: newCheckoutFlag) {
-    updateUI(value)
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .task { await appState.setup() }
+        }
+    }
 }
 
-// Combine publisher
+@MainActor
+class AppState: ObservableObject {
+    let configValues: ConfigValues
+
+    init() {
+        configValues = ConfigValues(
+            localProvider: nil,   // add a provider if needed
+            remoteProvider: nil,  // e.g. FirebaseConfigValueProvider()
+            onProviderError: { error in print("Featured error: \(error)") }
+        )
+    }
+
+    func setup() async {
+        do {
+            try await configValues.initialize()
+            try await configValues.fetch()
+        } catch {
+            print("Featured setup error: \(error)")
+        }
+    }
+}
+```
+
+## 4. Reading flags in Swift
+
+The SKIE bridge makes the Kotlin `ConfigValues` API available in Swift with async/await and `AsyncStream`.
+
+```swift
+import FeaturedCore
+
+// One-shot async read
+let configValue = try await configValues.getValue(param: FeatureFlags.shared.newCheckout)
+let isEnabled: Bool = configValue.value
+
+// AsyncStream — use in a Task or async for-await loop
+for await configValue in configValues.observe(param: FeatureFlags.shared.newCheckout) {
+    updateUI(configValue.value)
+}
+```
+
+## 5. Combine publisher
+
+SKIE wraps the Kotlin `Flow` as an `AsyncStream`. Combine publishers can be built on top using `AsyncStream.publisher`:
+
+```swift
+import Combine
+import FeaturedCore
+
+class CheckoutViewModel: ObservableObject {
+    @Published var isNewCheckoutEnabled: Bool = false
+
+    private var cancellables = Set<AnyCancellable>()
+    private let configValues: ConfigValues
+
+    init(configValues: ConfigValues) {
+        self.configValues = configValues
+    }
+
+    func startObserving() {
+        // Bridge AsyncStream → Combine publisher
+        let stream = configValues.observe(param: FeatureFlags.shared.newCheckout)
+
+        Task {
+            for await configValue in stream {
+                await MainActor.run {
+                    self.isNewCheckoutEnabled = configValue.value
+                }
+            }
+        }
+    }
+}
+```
+
+Alternatively, use `publisher(for:)` if your Swift wrapper exposes it:
+
+```swift
 featureFlags.publisher(for: newCheckoutFlag)
     .receive(on: DispatchQueue.main)
     .sink { isEnabled in updateUI(isEnabled) }
     .store(in: &cancellables)
 ```
 
-## Swift dead-code elimination via xcconfig
+## 6. SwiftUI integration
+
+Collect the flag value in a `@StateObject` ViewModel and bind it to the view:
+
+```swift
+struct CheckoutScreen: View {
+    @StateObject private var viewModel: CheckoutViewModel
+
+    var body: some View {
+        Group {
+            if viewModel.isNewCheckoutEnabled {
+                NewCheckoutView()
+            } else {
+                LegacyCheckoutView()
+            }
+        }
+        .task { viewModel.startObserving() }
+    }
+}
+```
+
+## 7. Swift dead-code elimination via xcconfig
 
 The Gradle plugin generates an xcconfig file that feeds Swift compilation conditions into Xcode. For every `@LocalFlag`-annotated `ConfigParam<Boolean>` with `defaultValue = false`, a `DISABLE_<FLAG_KEY>` condition is generated.
 
 ### Key transformation
 
-| Kotlin flag key | Generated condition |
-|-----------------|---------------------|
-| `new_checkout` | `DISABLE_NEW_CHECKOUT` |
-| `experimentalUi` | `DISABLE_EXPERIMENTAL_UI` |
+| Kotlin flag key   | Generated condition      |
+|-------------------|--------------------------|
+| `new_checkout`    | `DISABLE_NEW_CHECKOUT`   |
+| `experimentalUi`  | `DISABLE_EXPERIMENTAL_UI`|
 
 ### Step 1 — Generate the xcconfig
 
@@ -143,3 +253,9 @@ cp shared/build/featured/FeatureFlags.generated.xcconfig \
 ```
 
 For more detail, see the full [iOS Integration Guide](../ios-integration.md).
+
+## Next steps
+
+- [Android guide](android.md) — DataStore, Compose integration, and the debug UI
+- [JVM guide](jvm.md) — server and desktop integration
+- [Providers](providers.md) — all built-in providers in detail

--- a/docs/guides/jvm.md
+++ b/docs/guides/jvm.md
@@ -1,10 +1,8 @@
-# JVM Guide
+# JVM / Desktop Integration Guide
 
 Featured works on plain JVM targets (server, desktop, CLI) without any Android or iOS dependencies.
 
-## Installation
-
-Add only the `core` artifact — no Android or platform-specific modules are needed for JVM:
+## 1. Add Gradle dependencies
 
 ```kotlin title="build.gradle.kts"
 plugins {
@@ -13,11 +11,22 @@ plugins {
 
 dependencies {
     implementation(platform("dev.androidbroadcast.featured:featured-bom:<version>"))
+
+    // Core runtime — always required
     implementation("dev.androidbroadcast.featured:core")
+
+    // Persistent local provider backed by java.util.prefs.Preferences
+    implementation("dev.androidbroadcast.featured:javaprefs-provider")
+
+    // Test helper — add to test scope only
+    testImplementation("dev.androidbroadcast.featured:featured-testing")
 }
 ```
 
-## Declaring flags
+!!! note
+    The `javaprefs-provider` artifact is JVM-only. It does not pull in any Android or Apple platform dependencies.
+
+## 2. Declare flags
 
 Flags are declared identically to any other platform — `ConfigParam` is a common (KMP shared) type:
 
@@ -42,30 +51,69 @@ object FeatureFlags {
 }
 ```
 
-## Creating `ConfigValues`
+## 3. Create `ConfigValues` with `JavaPreferencesConfigValueProvider`
 
-On JVM, use `InMemoryConfigValueProvider` (built-in, no external dependencies) or write a custom `LocalConfigValueProvider`:
+`JavaPreferencesConfigValueProvider` persists values using `java.util.prefs.Preferences`. Storage is OS-specific: the registry on Windows, a plist on macOS, and `~/.java` on Linux. Values survive process restarts automatically.
 
 ```kotlin
 import dev.androidbroadcast.featured.ConfigValues
-import dev.androidbroadcast.featured.InMemoryConfigValueProvider
+import dev.androidbroadcast.featured.javaprefs.JavaPreferencesConfigValueProvider
+import java.util.prefs.Preferences
 
-val configValues = ConfigValues(
-    localProvider = InMemoryConfigValueProvider(),
+// Default: stores under the user root, node "featured"
+val provider = JavaPreferencesConfigValueProvider()
+
+// Custom node — useful for isolating test data or multiple app instances
+val provider = JavaPreferencesConfigValueProvider(
+    node = Preferences.userRoot().node("com/example/myapp/flags")
+)
+
+val configValues = ConfigValues(localProvider = provider)
+```
+
+### Supporting custom types
+
+Built-in support covers `String`, `Int`, `Boolean`, `Float`, `Long`, and `Double`. Register a `TypeConverter` for any additional type before first use:
+
+```kotlin
+import dev.androidbroadcast.featured.TypeConverter
+import dev.androidbroadcast.featured.javaprefs.registerConverter
+
+enum class Theme { LIGHT, DARK, SYSTEM }
+
+provider.registerConverter<Theme>(
+    TypeConverter(
+        fromString = { Theme.valueOf(it) },
+        toString = { it.name },
+    )
 )
 ```
 
-## Reading flags
+## 4. Initialize and fetch (optional)
+
+On JVM there is typically no remote provider, so `initialize()` and `fetch()` are not required. If you wire a remote provider (e.g., a custom `RemoteConfigValueProvider` backed by a feature-flag service), call them once on startup:
 
 ```kotlin
 import kotlinx.coroutines.runBlocking
 
-// One-shot read (from a coroutine or runBlocking in tests/scripts)
-val value = runBlocking { configValues.getValue(FeatureFlags.darkMode) }
-println("dark_mode = ${value.value} (source: ${value.source})")
+runBlocking {
+    configValues.initialize()
+    configValues.fetch()
+}
 ```
 
-## Reactive observation
+## 5. Read flags
+
+```kotlin
+import kotlinx.coroutines.runBlocking
+
+// One-shot read — from a coroutine or runBlocking in scripts / tests
+val value = runBlocking { configValues.getValue(FeatureFlags.darkMode) }
+println("dark_mode = ${value.value} (source: ${value.source})")
+// source is DEFAULT, LOCAL, or REMOTE
+```
+
+## 6. Reactive observation
 
 Featured uses Kotlin Coroutines' `Flow` for reactive updates on all platforms, including JVM:
 
@@ -80,17 +128,97 @@ runBlocking {
 }
 ```
 
-## Overriding at runtime
+In a long-lived server process, collect inside a `CoroutineScope` tied to the application lifecycle:
 
 ```kotlin
-// Apply a local override
-configValues.override(FeatureFlags.darkMode, true)
-
-// Reset to default
-configValues.resetOverride(FeatureFlags.darkMode)
+applicationScope.launch {
+    configValues.observe(FeatureFlags.darkMode).collect { configValue ->
+        // Reconfigure the application when the flag changes
+        updateTheme(configValue.value)
+    }
+}
 ```
 
-## Writing a custom provider
+## 7. Override and reset at runtime
+
+```kotlin
+// Apply a local override — useful for admin overrides or staged rollouts
+configValues.override(FeatureFlags.darkMode, true)
+
+// Reset to the stored or default value
+configValues.resetOverride(FeatureFlags.darkMode)
+
+// Clear all local overrides
+configValues.clearOverrides()
+```
+
+## 8. Testing with `FakeConfigValues`
+
+The `featured-testing` artifact provides `fakeConfigValues` — a suspend factory function that builds a `ConfigValues` backed by an in-memory provider. No real `Preferences` storage is involved.
+
+```kotlin
+import dev.androidbroadcast.featured.testing.fakeConfigValues
+import dev.androidbroadcast.featured.testing.fake
+import kotlinx.coroutines.test.runTest
+
+class FeatureFlagTest {
+
+    @Test
+    fun `new checkout is enabled when flag is on`() = runTest {
+        val configValues = fakeConfigValues {
+            set(FeatureFlags.newCheckout, true)
+        }
+
+        val value = configValues.getValue(FeatureFlags.newCheckout)
+        assertTrue(value.value)
+    }
+
+    @Test
+    fun `defaults are used when no override is set`() = runTest {
+        val configValues = fakeConfigValues()
+
+        val value = configValues.getValue(FeatureFlags.darkMode)
+        assertEquals(FeatureFlags.darkMode.defaultValue, value.value)
+    }
+}
+```
+
+You can also use the companion extension for a more idiomatic call site:
+
+```kotlin
+import dev.androidbroadcast.featured.ConfigValues
+import dev.androidbroadcast.featured.testing.fake
+
+val configValues = ConfigValues.fake {
+    set(FeatureFlags.pageSize, 50)
+}
+```
+
+### Simulating mid-test flag changes
+
+`fakeConfigValues` returns a real `ConfigValues` instance — you can call `override` to simulate remote pushes or user-triggered overrides:
+
+```kotlin
+@Test
+fun `UI updates when flag changes at runtime`() = runTest {
+    val configValues = fakeConfigValues {
+        set(FeatureFlags.newCheckout, false)
+    }
+
+    val collected = mutableListOf<Boolean>()
+    val job = launch {
+        configValues.observe(FeatureFlags.newCheckout).collect { collected.add(it.value) }
+    }
+
+    configValues.override(FeatureFlags.newCheckout, true)
+    advanceUntilIdle()
+
+    job.cancel()
+    assertEquals(listOf(false, true), collected)
+}
+```
+
+## 9. Writing a custom provider
 
 Implement `LocalConfigValueProvider` to back flags with any storage (database, config file, etc.):
 
@@ -109,22 +237,22 @@ class PropertiesConfigValueProvider(
         if (file.exists()) it.load(file.reader())
     }
 
-    override suspend fun <T : Any> getValue(param: ConfigParam<T>): ConfigValue<T>? {
+    override suspend fun <T : Any> get(param: ConfigParam<T>): ConfigValue<T>? {
         val raw = props.getProperty(param.key) ?: return null
         @Suppress("UNCHECKED_CAST")
         val value = raw as? T ?: return null
-        return ConfigValue(param, value, ConfigValue.Source.LOCAL)
+        return ConfigValue(value, ConfigValue.Source.LOCAL)
     }
 
-    override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>?> =
+    override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
         MutableStateFlow(null) // simplified — add file watching for full reactivity
 
-    override suspend fun <T : Any> setValue(param: ConfigParam<T>, value: T) {
+    override suspend fun <T : Any> set(param: ConfigParam<T>, value: T) {
         props.setProperty(param.key, value.toString())
         props.store(file.writer(), null)
     }
 
-    override suspend fun <T : Any> removeValue(param: ConfigParam<T>) {
+    override suspend fun <T : Any> resetOverride(param: ConfigParam<T>) {
         props.remove(param.key)
         props.store(file.writer(), null)
     }
@@ -135,3 +263,4 @@ class PropertiesConfigValueProvider(
 
 - [Providers](providers.md) — all built-in providers in detail
 - [Best practices](best-practices.md) — multi-module setup and testing
+- [Android guide](android.md) — DataStore, Compose integration, and the debug UI


### PR DESCRIPTION
## Summary

- **Android**: Full integration guide from scratch — Gradle dependencies, `Application.onCreate` initialization with DataStore and SharedPrefs providers, ViewModel pattern using `observe`/`asStateFlow`, Firebase Remote Config provider setup, debug UI registration behind `BuildConfig.DEBUG`, and ProGuard/R8 section
- **iOS**: Added `initialize()`/`fetch()` call in Swift app entry point, SwiftUI ViewModel pattern with `@Published`, expanded Combine publisher example bridging `AsyncStream` from SKIE
- **JVM**: Added `JavaPreferencesConfigValueProvider` with custom Preferences node, `TypeConverter` registration for enums, coroutine-scope observation for long-lived processes, and a full testing section using `fakeConfigValues` / `ConfigValues.fake` including mid-test override simulation

## Test plan

- [ ] All three guide files render correctly in mkdocs (`mkdocs serve`)
- [ ] Code snippets reference real API names: `SharedPreferencesProviderConfig`, `JavaPreferencesConfigValueProvider`, `fakeConfigValues`, `ConfigValues.fake`, `configValues.initialize()`, `configValues.fetch()`
- [ ] No broken links between guides
- [ ] mkdocs nav in `mkdocs.yml` already includes all three guides — no changes needed

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)