### PR TITLE
Fix Firebase fetch() KDoc to document CancellationException

### DIFF
--- a/providers/firebase/src/main/kotlin/dev/androidbroadcast/featured/firebase/FirebaseConfigValueProvider.kt
+++ b/providers/firebase/src/main/kotlin/dev/androidbroadcast/featured/firebase/FirebaseConfigValueProvider.kt
@@ -86,9 +86,13 @@ public class FirebaseConfigValueProvider(
      *
      * @param activate When `true`, calls `fetchAndActivate()` so values become available
      *   immediately after this call. When `false`, only fetches without activating.
-     * @throws FetchException if the Firebase fetch operation fails (e.g. network error,
-     *   timeout, or service unavailability). The [FetchException.cause] holds the original
-     *   exception for diagnostics. See [FetchException] for retry recommendations.
+     * @throws FetchException if the Firebase fetch operation fails for any reason, including
+     *   network errors, timeouts, or service unavailability. This wraps all non-cancellation
+     *   exceptions — including [RuntimeException] thrown by [kotlinx.coroutines.tasks.await]
+     *   on Firebase task failure. The [FetchException.cause] holds the original exception for
+     *   diagnostics. See [FetchException] for retry recommendations.
+     * @throws kotlinx.coroutines.CancellationException if the coroutine is cancelled while
+     *   the fetch is in progress; propagated without wrapping.
      */
     override suspend fun fetch(activate: Boolean) {
         val task =


### PR DESCRIPTION
## Summary
- Update KDoc on `FirebaseConfigValueProvider.fetch()` to accurately describe exception behavior
- Document that `CancellationException` is propagated without wrapping
- Document that all other exceptions (including `RuntimeException`) are wrapped in `FetchException`

The catch block was already fixed in a prior commit to rethrow `CancellationException` instead of `RuntimeException`, but the KDoc was not updated to reflect the new semantics.

## Test plan
- [ ] Verify KDoc renders correctly in IDE
- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)