### PR TITLE
Auto-wire ProGuard rules into Android builds via Variant API

### DIFF
--- a/featured-gradle-plugin/build.gradle.kts
+++ b/featured-gradle-plugin/build.gradle.kts
@@ -55,6 +55,7 @@ mavenPublishing {
 }
 
 dependencies {
+    compileOnly("com.android.tools.build:gradle:9.1.0")
     testImplementation(gradleTestKit())
     testImplementation(libs.kotlin.testJunit)
     testImplementation(libs.r8)

--- a/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/AndroidProguardWiring.kt
+++ b/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/AndroidProguardWiring.kt
@@ -1,0 +1,26 @@
+package dev.androidbroadcast.featured.gradle
+
+import com.android.build.api.variant.AndroidComponentsExtension
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+
+/**
+ * Wires the generated ProGuard rules file into every Android variant via the AGP Variant API.
+ *
+ * Called lazily — only when `com.android.application` or `com.android.library` is present on
+ * the project. The task dependency is implicit through the [TaskProvider] chain, so no explicit
+ * `dependsOn` is required.
+ */
+internal fun wireProguardToVariants(
+    project: Project,
+    proguardTask: TaskProvider<GenerateProguardRulesTask>,
+) {
+    val androidComponents =
+        project.extensions
+            .getByType(AndroidComponentsExtension::class.java)
+    androidComponents.onVariants { variant ->
+        variant.proguardFiles.add(
+            proguardTask.flatMap { it.outputFile },
+        )
+    }
+}

--- a/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/AndroidProguardWiring.kt
+++ b/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/AndroidProguardWiring.kt
@@ -8,8 +8,10 @@ import org.gradle.api.tasks.TaskProvider
  * Wires the generated ProGuard rules file into every Android variant via the AGP Variant API.
  *
  * Called lazily — only when `com.android.application` or `com.android.library` is present on
- * the project. The task dependency is implicit through the [TaskProvider] chain, so no explicit
- * `dependsOn` is required.
+ * the project.
+ *
+ * AGP 9.x does not propagate implicit Gradle task dependencies through [Variant.proguardFiles],
+ * so [proguardTask] is also wired explicitly as a dependency of every `minify*WithR8` task.
  */
 internal fun wireProguardToVariants(
     project: Project,
@@ -22,5 +24,12 @@ internal fun wireProguardToVariants(
         variant.proguardFiles.add(
             proguardTask.flatMap { it.outputFile },
         )
+    }
+    // AGP 9.x does not propagate implicit task dependencies through variant.proguardFiles,
+    // so we wire an explicit dependsOn on every R8 minify task.
+    project.tasks.configureEach { task ->
+        if (task.name.startsWith("minify") && task.name.endsWith("WithR8")) {
+            task.dependsOn(proguardTask)
+        }
     }
 }

--- a/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/FeaturedPlugin.kt
+++ b/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/FeaturedPlugin.kt
@@ -51,10 +51,15 @@ public class FeaturedPlugin : Plugin<Project> {
 
         registerConfigParamTask(target, resolveTask)
         registerFlagRegistrarTask(target, resolveTask)
-        registerProguardTask(target, resolveTask)
+        val proguardTask = registerProguardTask(target, resolveTask)
         registerIosConstValTask(target, resolveTask)
         registerXcconfigTask(target, resolveTask)
         wireToRootAggregator(target, resolveTask)
+        listOf("com.android.application", "com.android.library").forEach { pluginId ->
+            target.plugins.withId(pluginId) {
+                wireProguardToVariants(target, proguardTask)
+            }
+        }
     }
 
     private fun registerResolveFlagsTask(target: Project): TaskProvider<ResolveFlagsTask> =
@@ -99,7 +104,7 @@ public class FeaturedPlugin : Plugin<Project> {
     private fun registerProguardTask(
         target: Project,
         resolveTask: TaskProvider<ResolveFlagsTask>,
-    ) {
+    ): TaskProvider<GenerateProguardRulesTask> =
         target.tasks.register(GENERATE_PROGUARD_TASK_NAME, GenerateProguardRulesTask::class.java) { task ->
             task.group = "featured"
             task.description = "Generates ProGuard/R8 -assumevalues rules for local flags in '${target.path}'."
@@ -108,7 +113,6 @@ public class FeaturedPlugin : Plugin<Project> {
             task.outputFile.set(target.layout.buildDirectory.file("featured/proguard-featured.pro"))
             task.dependsOn(resolveTask)
         }
-    }
 
     private fun registerIosConstValTask(
         target: Project,

--- a/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/GenerateProguardRulesTask.kt
+++ b/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/GenerateProguardRulesTask.kt
@@ -19,19 +19,8 @@ import org.gradle.api.tasks.TaskAction
  * [ExtensionFunctionGenerator], so R8 can propagate the exact constant and eliminate
  * dead branches in release builds.
  *
- * Wire the generated file into your Android module's ProGuard configuration:
- * ```kotlin
- * android {
- *     buildTypes {
- *         release {
- *             proguardFiles(
- *                 getDefaultProguardFile("proguard-android-optimize.txt"),
- *                 layout.buildDirectory.file("featured/proguard-featured.pro").get().asFile,
- *             )
- *         }
- *     }
- * }
- * ```
+ * For Android projects the generated file is automatically wired into all variants via the
+ * AGP Variant API — no manual ProGuard configuration is required.
  */
 @CacheableTask
 public abstract class GenerateProguardRulesTask : DefaultTask() {


### PR DESCRIPTION
## Summary
- Add `AndroidProguardWiring.kt` that uses the AGP Variant API to inject generated ProGuard rules into every Android variant
- Update `FeaturedPlugin` to detect `com.android.application`/`com.android.library` and call `wireProguardToVariants()` lazily
- Change `registerProguardTask()` to return `TaskProvider<GenerateProguardRulesTask>` for downstream wiring
- Add `compileOnly` dependency on AGP 9.1.0
- Update `GenerateProguardRulesTask` KDoc to reflect automatic wiring (remove manual configuration example)

Consumers no longer need to manually add `proguardFiles(...)` for the Featured plugin's generated rules — the plugin handles it automatically via the Variant API.

## Test plan
- [ ] Apply the plugin to an Android app/library module and verify `assembleRelease` includes the generated `proguard-featured.pro`
- [ ] Verify non-Android modules (pure JVM/KMP) still work without AGP on the classpath
- [ ] Verify `generateProguardRules` task still works standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)