### PR TITLE
Remove unused kotlinAndroid plugin — AGP 9 migration complete

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
     alias(libs.plugins.composeMultiplatform) apply false
     alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
-    alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.kotlinJvm) apply false
     alias(libs.plugins.spotless)
     alias(libs.plugins.mavenPublish) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,7 +84,6 @@ composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "com
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 skie = { id = "co.touchlab.skie", version.ref = "skie" }


### PR DESCRIPTION
## Summary

- `gradle/libs.versions.toml`: remove `kotlinAndroid` plugin entry (`org.jetbrains.kotlin.android`)
- `build.gradle.kts` (root): remove `alias(libs.plugins.kotlinAndroid) apply false`

With `android.builtInKotlin=true` AGP 9 provides Kotlin support for all Android modules directly. The `kotlinAndroid` plugin was never applied by any module — its catalog entry and root registration were stale leftovers from before the migration.

All KMP+Android modules have been on `com.android.kotlin.multiplatform.library` since earlier commits. Pure-Android modules (`firebase`, `sharedpreferences`) rely on built-in Kotlin via `android.builtInKotlin=true`. The project builds and passes `spotlessCheck` cleanly.

## Closes

Closes #129
Closes #130
Closes #131
Closes #132
Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)