### PR TITLE
Fix license mismatch: use MIT in all POM declarations

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 1.x     | ✅        |
+
+## Reporting a Vulnerability
+
+Please use [GitHub private vulnerability reporting](https://github.com/AndroidBroadcast/Featured/security/advisories/new)
+or email kirill@androidbroadcast.dev.
+
+Do not open a public issue for security vulnerabilities.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -105,8 +105,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/featured-bom/build.gradle.kts
+++ b/featured-bom/build.gradle.kts
@@ -41,8 +41,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/featured-compose/build.gradle.kts
+++ b/featured-compose/build.gradle.kts
@@ -70,8 +70,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/featured-debug-ui/build.gradle.kts
+++ b/featured-debug-ui/build.gradle.kts
@@ -72,8 +72,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/featured-detekt-rules/build.gradle.kts
+++ b/featured-detekt-rules/build.gradle.kts
@@ -28,8 +28,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/featured-gradle-plugin/build.gradle.kts
+++ b/featured-gradle-plugin/build.gradle.kts
@@ -34,8 +34,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/featured-lint-rules/build.gradle.kts
+++ b/featured-lint-rules/build.gradle.kts
@@ -36,8 +36,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/featured-platform/build.gradle.kts
+++ b/featured-platform/build.gradle.kts
@@ -78,8 +78,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/featured-registry/build.gradle.kts
+++ b/featured-registry/build.gradle.kts
@@ -88,8 +88,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/featured-testing/build.gradle.kts
+++ b/featured-testing/build.gradle.kts
@@ -66,8 +66,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/providers/configcat/build.gradle.kts
+++ b/providers/configcat/build.gradle.kts
@@ -70,8 +70,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/providers/datastore/build.gradle.kts
+++ b/providers/datastore/build.gradle.kts
@@ -86,8 +86,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/providers/firebase/build.gradle.kts
+++ b/providers/firebase/build.gradle.kts
@@ -51,8 +51,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/providers/javaprefs/build.gradle.kts
+++ b/providers/javaprefs/build.gradle.kts
@@ -39,8 +39,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/providers/nsuserdefaults/build.gradle.kts
+++ b/providers/nsuserdefaults/build.gradle.kts
@@ -47,8 +47,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }

--- a/providers/sharedpreferences/build.gradle.kts
+++ b/providers/sharedpreferences/build.gradle.kts
@@ -64,8 +64,8 @@ mavenPublishing {
         url.set("https://github.com/AndroidBroadcast/Featured")
         licenses {
             license {
-                name.set("The Apache Software License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
                 distribution.set("repo")
             }
         }


### PR DESCRIPTION
## Summary

- All 16 `build.gradle.kts` publishing blocks declared Apache 2.0 in their POM `<licenses>` section, contradicting the MIT `LICENSE` file and README badge
- Changed `name` to `"MIT License"` and `url` to `"https://opensource.org/licenses/MIT"` in every affected module

Closes #168