### PR TITLE
Add GitHub issue templates and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug Report
+description: Report a bug in Featured
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for reporting a bug!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Configure '...'
+        2. Call '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Library Version
+      placeholder: e.g. 1.0.0
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      multiple: true
+      options:
+        - Android
+        - iOS
+        - JVM
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem (logs, stack traces, etc.)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/AndroidBroadcast/Featured/discussions
+    about: Ask questions and discuss ideas here instead of opening issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for suggesting an improvement!
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem does this feature solve? Why is it needed?
+    validations:
+      required: true
+  - type: textarea
+    id: api
+    attributes:
+      label: Proposed API
+      description: If applicable, show what the API would look like.
+      render: kotlin
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches did you consider?
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation
+- [ ] Chore / refactor
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] Docs updated (KDoc, README, CHANGELOG)
+- [ ] `./gradlew spotlessCheck` passes
+- [ ] CHANGELOG.md updated
+
+## Notes for reviewers


### PR DESCRIPTION
Closes #170

## What changed

- Added `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, directs questions to Discussions
- Added `.github/ISSUE_TEMPLATE/bug_report.yml` — structured bug report form with description, reproduction steps, expected/actual behavior, library version, and platform fields
- Added `.github/ISSUE_TEMPLATE/feature_request.yml` — structured feature request form with motivation, proposed API (Kotlin render), alternatives, and context fields
- Added `.github/pull_request_template.md` — PR template with type-of-change checklist, contributor checklist (tests, docs, spotlessCheck, CHANGELOG), and notes-for-reviewers section

## Why

Standardizes how contributors report bugs and request features, reduces triage overhead, and ensures PRs consistently reference the related issue and pass quality gates before review.

## How to test

Open a new issue on GitHub — blank issue option should be absent; two structured forms (Bug Report, Feature Request) should appear. Open a new PR — the body should be pre-filled with the template.