### PR TITLE
feat(platform): use JavaPreferencesConfigValueProvider on JVM

### DIFF
--- a/featured-platform/build.gradle.kts
+++ b/featured-platform/build.gradle.kts
@@ -59,6 +59,10 @@ kotlin {
         iosMain.dependencies {
             implementation(project(":providers:nsuserdefaults"))
         }
+
+        jvmMain.dependencies {
+            implementation(project(":providers:javaprefs"))
+        }
     }
 }
 

--- a/featured-platform/src/commonMain/kotlin/dev/androidbroadcast/featured/platform/DefaultLocalProvider.kt
+++ b/featured-platform/src/commonMain/kotlin/dev/androidbroadcast/featured/platform/DefaultLocalProvider.kt
@@ -8,7 +8,7 @@ import dev.androidbroadcast.featured.LocalConfigValueProvider
  * | Platform | Implementation |
  * |----------|----------------|
  * | iOS      | [dev.androidbroadcast.featured.nsuserdefaults.NSUserDefaultsConfigValueProvider] |
- * | JVM      | [dev.androidbroadcast.featured.InMemoryConfigValueProvider] (persistent provider pending #66) |
+ * | JVM      | [dev.androidbroadcast.featured.javaprefs.JavaPreferencesConfigValueProvider] |
  * | Android  | [dev.androidbroadcast.featured.InMemoryConfigValueProvider] (non-persistent, deprecated) |
  *
  * **Android note:** On Android this overload is deprecated and returns a non-persistent

--- a/featured-platform/src/jvmMain/kotlin/dev/androidbroadcast/featured/platform/DefaultLocalProvider.kt
+++ b/featured-platform/src/jvmMain/kotlin/dev/androidbroadcast/featured/platform/DefaultLocalProvider.kt
@@ -1,16 +1,9 @@
 package dev.androidbroadcast.featured.platform
 
-import dev.androidbroadcast.featured.InMemoryConfigValueProvider
 import dev.androidbroadcast.featured.LocalConfigValueProvider
-
-// TODO(#66): Replace with JavaPreferencesConfigValueProvider once available.
+import dev.androidbroadcast.featured.javaprefs.JavaPreferencesConfigValueProvider
 
 /**
- * Returns an [InMemoryConfigValueProvider] on JVM.
- *
- * A persistent JVM provider (Java Preferences-backed) is tracked in issue #66.
- * Until that module ships, this returns an in-memory provider so integrators can
- * adopt the `defaultLocalProvider()` call site today and benefit from persistence
- * automatically once #66 lands.
+ * Returns a [JavaPreferencesConfigValueProvider] on JVM (persists via `java.util.prefs.Preferences`).
  */
-public actual fun defaultLocalProvider(): LocalConfigValueProvider = InMemoryConfigValueProvider()
+public actual fun defaultLocalProvider(): LocalConfigValueProvider = JavaPreferencesConfigValueProvider()


### PR DESCRIPTION
## Summary

- Replaces `InMemoryConfigValueProvider` with `JavaPreferencesConfigValueProvider` as the default JVM local provider in `featured-platform`
- Adds `jvmMain` dependency on `:providers:javaprefs` in `featured-platform/build.gradle.kts`
- Updates KDoc in both common and JVM actual files; removes TODO and references to issue #66

Closes #167

## Test plan

- [x] `./gradlew :featured-platform:build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)