### PR TITLE
Fix stale artifact IDs in quick-start docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Featured
 
 [![CI](https://github.com/AndroidBroadcast/Featured/actions/workflows/ci.yml/badge.svg)](https://github.com/AndroidBroadcast/Featured/actions/workflows/ci.yml)
-[![Maven Central](https://img.shields.io/maven-central/v/dev.androidbroadcast.featured/core.svg?label=Maven%20Central)](https://central.sonatype.com/search?q=dev.androidbroadcast.featured)
+[![Maven Central](https://img.shields.io/maven-central/v/dev.androidbroadcast.featured/featured-core.svg?label=Maven%20Central)](https://central.sonatype.com/search?q=dev.androidbroadcast.featured)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 **Featured** is a type-safe, reactive feature-flag and configuration management library for Kotlin Multiplatform (Android, iOS, JVM). Declare flags in shared Kotlin code, read them at runtime from local or remote providers, and let the Gradle plugin dead-code-eliminate disabled flags from your production binaries.
@@ -67,7 +67,7 @@ dependencies {
     implementation(platform("dev.androidbroadcast.featured:featured-bom:<version>"))
 
     // Core runtime — always required
-    implementation("dev.androidbroadcast.featured:core")
+    implementation("dev.androidbroadcast.featured:featured-core")
 
     // Optional modules — add only what you use
     implementation("dev.androidbroadcast.featured:featured-compose")         // Compose extensions
@@ -75,11 +75,11 @@ dependencies {
     debugImplementation("dev.androidbroadcast.featured:featured-debug-ui")   // Debug screen
 
     // Local persistence providers — pick one (or both)
-    implementation("dev.androidbroadcast.featured:datastore-provider")
-    implementation("dev.androidbroadcast.featured:sharedpreferences-provider")
+    implementation("dev.androidbroadcast.featured:featured-datastore-provider")
+    implementation("dev.androidbroadcast.featured:featured-sharedpreferences-provider")
 
     // Remote provider
-    implementation("dev.androidbroadcast.featured:firebase-provider")
+    implementation("dev.androidbroadcast.featured:featured-firebase-provider")
 }
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ dependencies {
     implementation(platform("dev.androidbroadcast.featured:featured-bom:<version>"))
 
     // Core runtime — always required
-    implementation("dev.androidbroadcast.featured:core")
+    implementation("dev.androidbroadcast.featured:featured-core")
 
     // Optional modules — add only what you use
     implementation("dev.androidbroadcast.featured:featured-compose")         // Compose extensions
@@ -34,11 +34,11 @@ dependencies {
     debugImplementation("dev.androidbroadcast.featured:featured-debug-ui")   // Debug screen
 
     // Local persistence providers — pick one (or both)
-    implementation("dev.androidbroadcast.featured:datastore-provider")
-    implementation("dev.androidbroadcast.featured:sharedpreferences-provider")
+    implementation("dev.androidbroadcast.featured:featured-datastore-provider")
+    implementation("dev.androidbroadcast.featured:featured-sharedpreferences-provider")
 
     // Remote provider
-    implementation("dev.androidbroadcast.featured:firebase-provider")
+    implementation("dev.androidbroadcast.featured:featured-firebase-provider")
 }
 ```
 


### PR DESCRIPTION
## Summary

- `README.md` and `docs/getting-started.md` both referenced incorrect Maven artifact coordinates that were missing the `featured-` prefix
- Fixed four artifact IDs: `core` → `featured-core`, `datastore-provider` → `featured-datastore-provider`, `sharedpreferences-provider` → `featured-sharedpreferences-provider`, `firebase-provider` → `featured-firebase-provider`
- Fixed Maven Central badge URL in `README.md` (same `core` → `featured-core` mismatch)
- All other quick-start content verified against source: class/function names, `ConfigValues` constructor, `FlagRegistry.register()`, `FeatureFlagsDebugScreen`, `SharedPreferencesProviderConfig`, SPM product name `FeaturedCore`, iOS xcconfig steps, Gradle plugin ID — all accurate

**Note on task brief:** The brief stated "`defaultLocalProvider()` on JVM now returns `JavaPreferencesConfigValueProvider` (just merged)". The actual `origin/main` source for JVM still returns `InMemoryConfigValueProvider` with a `TODO(#66)` comment. No docs reference JVM provider behaviour in the quick-start, so there is nothing to fix there — but the task description appears to describe work that has not yet landed on `main`.

## Test plan

- [ ] Verify artifact coordinates resolve on Maven Central: `dev.androidbroadcast.featured:featured-core`, `featured-datastore-provider`, `featured-sharedpreferences-provider`, `featured-firebase-provider`

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)