### PR TITLE
Wire lint detectors into core AAR via lintPublish

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -64,6 +64,16 @@ kotlin {
     }
 }
 
+configurations.named("lintPublish") {
+    // kotlin-stdlib is provided by the lint host at runtime; exclude it so AGP
+    // sees exactly one JAR in lintPublish and does not fail with "Found more than one jar".
+    isTransitive = false
+}
+
+dependencies {
+    lintPublish(project(":featured-lint-rules"))
+}
+
 // Zips the release XCFramework for distribution via Swift Package Manager.
 // Output: build/xcframeworks/FeaturedCore.xcframework.zip
 val zipXCFramework by tasks.registering(Zip::class) {

--- a/sample/android-app/build.gradle.kts
+++ b/sample/android-app/build.gradle.kts
@@ -24,6 +24,11 @@ android {
         versionName = "1.0.0"
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+
     buildFeatures {
         compose = true
     }


### PR DESCRIPTION
Without `lintPublish`, the four lint detectors (#157, #158, #159 + existing HardcodedFlagValue) were published as a separate artifact but **never activated automatically** in Android Studio — users would have to add `featured-lint-rules` manually.

## Changes

### `core/build.gradle.kts`
- Adds `lintPublish(project(":featured-lint-rules"))` so the lint JAR is embedded in `featured-core.aar`
- Sets `isTransitive = false` on the `lintPublish` configuration — `kotlin-stdlib` is provided by the lint host at runtime; without this AGP fails with "Found more than one jar in lintPublish"

### `sample/android-app/build.gradle.kts`
- Adds `compileOptions { sourceCompatibility/targetCompatibility = VERSION_21 }` to match upstream modules (core, platform, etc. all compile to JVM 21); without this, Kotlin inline functions from JVM-21-compiled deps cause a compile error

## Verification

```
lint.jar embedded in AAR:
  core/build/outputs/aar/core.aar → contains lint.jar ✅

Detector fires on consumer code:
  :sample:android-app:lintRelease →
  Warning: Accessing defaultValue directly on a ConfigParam ... [HardcodedFlagValue] ✅
```

Closes #— (no issue, discovered during v1.0.0 pre-release verification)