### PR TITLE
Prepare 1.0.0-Beta1 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,9 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}
           ORG_GRADLE_PROJECT_VERSION_NAME: ${{ steps.version.outputs.VERSION_NAME }}
-        run: ./gradlew --no-daemon publishAllPublicationsToMavenCentralRepository
+        # publishToMavenCentral = manual promotion (no auto-release); --no-configuration-cache for
+        # release-pipeline debuggability (runs once per tag, CC savings are zero).
+        run: ./gradlew --no-daemon publishToMavenCentral --no-configuration-cache
 
   publish-xcframework:
     name: Publish XCFramework to GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `clear()` method on `LocalConfigValueProvider` interface (#101)
 - Graceful error handling when a provider fails (#100)
 - Multivariate flag support — `enum` and sealed class `ConfigParam` types (#99)
-- SKIE 0.10.5 bridge for Swift interop (coroutines, sealed classes, default arguments)
+- SKIE 0.10.10 bridge for Swift interop (coroutines, sealed classes, default arguments)
 - Combine `Publisher` support in `FeatureFlags.swift` (#88)
 - XCFramework published as Swift Package Manager artifact (#91)
 
@@ -66,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Migrated to AGP 9.1.0 + Gradle 9.3.1 with full KMP plugin support (#135)
+- Migrated to AGP 9.1.0 + Gradle 9.4.1 with full KMP plugin support (#135)
 - Moved all provider modules under `providers/` directory (#128)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,38 +7,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-Beta1] - 2026-05-17
+
 ### Added
 
-- Configuration Cache support (Gradle 9+, AGP 9+) for `featured-gradle-plugin`
-- `NSUserDefaultsConfigValueProvider` for iOS/macOS local storage (#104)
+#### Core library
+
+- Core KMP library: `ConfigParam`, `ConfigValue`, `ConfigValues` with reactive `Flow` API
+- Explicit initialization mechanism for `ConfigValues` (#98)
 - `clear()` method on `LocalConfigValueProvider` interface (#101)
 - Graceful error handling when a provider fails (#100)
 - Multivariate flag support — `enum` and sealed class `ConfigParam` types (#99)
-- Explicit initialization mechanism for `ConfigValues` (#98)
+- SKIE 0.10.5 bridge for Swift interop (coroutines, sealed classes, default arguments)
+- Combine `Publisher` support in `FeatureFlags.swift` (#88)
+- XCFramework published as Swift Package Manager artifact (#91)
+
+#### Providers
+
+- `InMemoryConfigValueProvider` — built-in in-memory local provider
+- `SharedPreferencesConfigValueProvider` — local storage via SharedPreferences
+- `DataStoreConfigValueProvider` — local storage via Jetpack DataStore
+- `JavaPreferencesConfigValueProvider` — default JVM local provider (#167, #178)
+- `NSUserDefaultsConfigValueProvider` for iOS/macOS local storage (#104)
+- `FirebaseConfigValueProvider` — remote config via Firebase Remote Config
+
+#### Gradle plugin and code generation
+
+- `featured-gradle-plugin` module — code generation for Kotlin, iOS, and ProGuard (#72, #76, #80, #83, #86)
+- Declare flags via Gradle DSL; auto-generate typed extensions and per-function R8 rules
+- Enum-typed flags in Gradle DSL (#162)
+- Auto-generated `FlagRegistry` initializers per module (#110)
+- Auto-wired ProGuard rules into Android builds via AGP Variant API
+- Configuration Cache support (Gradle 9+, AGP 9+) (#164)
+- E2E integration test for `featured-gradle-plugin`
+- `featured-shrinker-tests` — R8 dead-code-elimination verification module (#165)
+
+#### Static analysis
+
+- `featured-lint-rules` Android Lint module with `HardcodedFlagValue`, `UncheckedFlagAccess`, `ExpiredFeatureFlag`, and `InvalidFlagReference` detectors (#141, #176, #181)
+- Detekt rules: `@BehindFlag` / `@AssumesFlag` annotations and `InvalidFlagReference` / `UncheckedFlagAccess` rules (#142)
+
+#### Compose and tooling
+
+- `featured-compose` module — `LocalConfigValues` CompositionLocal and `collectAsState` (#73, #78)
+- `featured-debug-ui` module — Compose Multiplatform flag override UI (#79)
+- `featured-registry` module — declarative flag scanning across modules (#74)
 - `featured-testing` module with `FakeConfigValues` and test DSL (#97)
-- MkDocs Material documentation website (#96)
+
+#### Packaging and docs
+
 - Bill of Materials (`featured-bom`) module (#82)
 - Maven Central publishing for all modules (#81)
-- `featured-debug-ui` module — Compose Multiplatform flag override UI (#79, #648f38e)
-- `featured-gradle-plugin` module — code generation for Kotlin, iOS, and ProGuard (#72, #76, #80, #83, #86)
-- `featured-registry` module — declarative flag scanning across modules (#74)
-- `featured-compose` module — `LocalConfigValues` CompositionLocal and `collectAsState` (#73, #78)
-- XCFramework published as Swift Package Manager artifact (#91)
-- Combine `Publisher` support in `FeatureFlags.swift` (#88)
 - Dokka API reference generation (#92)
-- `FirebaseConfigValueProvider` — remote config via Firebase Remote Config
-- `DataStoreConfigValueProvider` — local storage via Jetpack DataStore
-- `SharedPreferencesConfigValueProvider` — local storage via SharedPreferences
-- `InMemoryConfigValueProvider` — built-in in-memory local provider
-- Core KMP library: `ConfigParam`, `ConfigValue`, `ConfigValues` with reactive `Flow` API
-- SKIE 0.10.5 bridge for Swift interop (coroutines, sealed classes, default arguments)
-- Binary Compatibility Validator (BCV) API dump for all modules (#95)
+- MkDocs Material documentation website (#96)
 - DI pattern documentation for multi-module `ConfigValues` usage (#93)
+- `SECURITY.md` with vulnerability disclosure policy (#173)
+- GitHub issue templates and pull-request template (#175)
+
+### Changed
+
+- Migrated to AGP 9.1.0 + Gradle 9.3.1 with full KMP plugin support (#135)
+- Moved all provider modules under `providers/` directory (#128)
+
+### Removed
+
+- `binary-compatibility-validator` (BCV) plugin from all modules (#150)
+- `@LocalFlag` / `@RemoteFlag` annotations from public API
 
 ### Fixed
 
-- `ConfigValues.observe()` not reacting to remote provider changes (#c0e0557)
-- Xcode build: JAVA_HOME, FRAMEWORK_SEARCH_PATHS, and Swift module import (#1c488ca)
+- `ConfigValues.observe()` not reacting to remote provider changes
+- Xcode build: `JAVA_HOME`, `FRAMEWORK_SEARCH_PATHS`, and Swift module import
 - `@MainActor` and `Sendable` conformance in `FeatureFlags.swift` (#85)
+- `FirebaseConfigValueProvider.fetch()` now wraps `RuntimeException` in `FetchException` (#151)
+- License mismatch: use MIT in all POM declarations (#174)
+- Stale artifact IDs in quick-start docs (#179)
 
-[Unreleased]: https://github.com/androidbroadcast/Featured/compare/HEAD...HEAD
+[Unreleased]: https://github.com/androidbroadcast/Featured/compare/v1.0.0-Beta1...HEAD
+[1.0.0-Beta1]: https://github.com/androidbroadcast/Featured/releases/tag/v1.0.0-Beta1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Swift API: `ConfigParam.description` is now exposed as `.summary` (via `@ObjCName`), avoiding the SKIE-generated `description_` workaround for the `NSObject.description()` collision
 - `ConfigValues.observe()` not reacting to remote provider changes
 - Xcode build: `JAVA_HOME`, `FRAMEWORK_SEARCH_PATHS`, and Swift module import
 - `@MainActor` and `Sendable` conformance in `FeatureFlags.swift` (#85)

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigParam.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigParam.kt
@@ -1,7 +1,9 @@
 @file:Suppress("unused")
+@file:OptIn(kotlin.experimental.ExperimentalObjCName::class)
 
 package dev.androidbroadcast.featured
 
+import kotlin.native.ObjCName
 import kotlin.reflect.KClass
 
 /**
@@ -44,6 +46,7 @@ public class ConfigParam<T : Any>
          * An optional description for the configuration parameter.
          * This can be used to provide additional context or information about the parameter.
          */
+        @property:ObjCName("summary")
         public val description: String? = null,
         /**
          * Category or group name for organizing related parameters.

--- a/featured-bom/build.gradle.kts
+++ b/featured-bom/build.gradle.kts
@@ -20,7 +20,9 @@ dependencies {
         api(project(":featured-compose"))
         api(project(":featured-registry"))
         api(project(":featured-debug-ui"))
+        api(project(":featured-testing"))
         api(project(":featured-gradle-plugin"))
+        api(project(":featured-lint-rules"))
 
         api(project(":featured-platform"))
         api(project(":featured-detekt-rules"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ android.r8.strictInputValidation=true
 android.proguard.failOnMissingFiles=true
 
 # Publishing
-VERSION_NAME=0.1.0-SNAPSHOT
+VERSION_NAME=1.0.0-Beta1
 
 # Dokka
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
## Summary

Prepares the first Beta of v1.0.0 (closes #166, refs #156).

Five atomic commits:

1. **Finalize CHANGELOG for 1.0.0-Beta1 release.** Rename `[Unreleased]` → `[1.0.0-Beta1] - 2026-05-17`, add new empty `[Unreleased]`, compare-link `[1.0.0-Beta1]: …/releases/tag/v1.0.0-Beta1`. Restructure `### Added` by area. Backfill items audited against `git log` (enum DSL #162, CC support #164, JavaPreferences default #167, lint detectors #141/#176/#181, Detekt rules #142, `FlagRegistry` codegen #110, ProGuard auto-wire, E2E test, R8 DCE module #165, SECURITY.md #173, GitHub templates #175). Add `### Changed` (AGP 9.1 + Gradle 9.3 #135, providers/ reshuffle #128) and `### Removed` (BCV #150, `@LocalFlag`/`@RemoteFlag`). Backfill `### Fixed` (Firebase fetch wrapping #151, MIT POM #174, quickstart docs #179).

2. **Bump `VERSION_NAME` to `1.0.0-Beta1`.** Release commit; `publish.yml` derives the published Maven Central version from the `v1.0.0-Beta1` tag, but `VERSION_NAME` is the SNAPSHOT baseline — keeping it on `1.0.0-Beta1` makes post-release SNAPSHOT builds (`1.0.0-Beta1-SNAPSHOT`) meaningful.

3. **Switch Maven Central publishing to Central Portal.** `publish.yml` now invokes `publishToMavenCentral` (manual promotion) instead of the legacy `publishAllPublicationsToMavenCentralRepository`. vanniktech 0.36 removed the OSSRH path — Central Portal is the only target. No build.gradle.kts changes needed. `--no-configuration-cache` added for release-pipeline debuggability. CI secrets (`MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD`) must be Central Portal User Tokens (central.sonatype.com → Account → Generate User Token).

4. **Add featured-lint-rules and featured-testing to BOM.** Both modules publish to Maven Central but were missing from the BOM, forcing consumers to pin versions manually. Adding them restores the BOM contract: every published Featured artifact is version-managed through featured-bom.

5. **Expose ConfigParam.description as .summary in Swift via @ObjCName.** Avoids SKIE's auto-rename to description_ caused by the NSObject.description() collision. Kotlin API unchanged.

## Release flow after merge

1. Merge this PR with `Squash and merge` (or `Rebase` to keep five commits — preference of maintainer).
2. Push tag `v1.0.0-Beta1` on the merge commit → triggers `publish.yml` (Maven Central staging + XCFramework GitHub release).
3. Review the staging deployment at central.sonatype.com/publishing/deployments and click **Publish** to promote.

## Test plan

- [ ] Visual diff of `CHANGELOG.md` (subsections, links, all PR numbers)
- [ ] `gradle.properties` shows `VERSION_NAME=1.0.0-Beta1`
- [ ] `publish.yml` step invokes `publishToMavenCentral --no-configuration-cache`
- [ ] `featured-bom` POM contains 15 managed artifacts (was 13)
- [ ] `ConfigParam.description` accessible as `.summary` in Swift (no `description_`)
- [ ] No other source files touched
- [ ] CI green