### PR TITLE
Bind publish job to Main environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
   publish:
     name: Publish to Maven Central
     runs-on: ubuntu-latest
+    environment: Main
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Secrets (MAVEN_CENTRAL_*, GPG_*) are declared at the **environment** level (`Main`), not at the repo level.
- Without `environment: Main` on the publish job, GitHub Actions injects empty values into `${{ secrets.* }}`, surfacing as `Could not read PGP secret key` when Gradle's signing plugin tries to use an empty `signingInMemoryKey`.
- This is the actual root cause of the failing tag publish (#188 v1.0.0-Beta1) — the secret values themselves were fine.

## Test plan

- [ ] Merge → re-run [failed publish run 25993650354](https://github.com/androidbroadcast/Featured/actions/runs/25993650354) → expect `:featured-bom:signMavenPublication` to succeed and bundle to upload to Central Portal.
- [ ] Verify in https://central.sonatype.com/publishing/deployments that `dev.androidbroadcast.featured:1.0.0-Beta1` appears in `VALIDATED` status (local publish already produced one — this CI bundle will be the second).