### PR TITLE
Run CI / CodeQL / Dependency Review on develop pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
   schedule:
     - cron: "0 0 * * 0"  # Every Sunday at midnight
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - develop
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-*"


### PR DESCRIPTION
## Why

The repo uses **main** (released code) + **develop** (integration). The `develop` ruleset requires status checks `Build Android`, `Build Docs`, and `Build iOS`, but the workflows producing those checks are configured with `pull_request.branches: [ main ]` only. PRs targeting `develop` (e.g. #190) therefore never run the required checks and stay in `mergeStateStatus: BLOCKED` forever.

## What

Add `develop` to PR triggers (and post-merge push triggers where appropriate) in four workflow files:

| File | `push.branches` | `pull_request.branches` |
|------|-----------------|--------------------------|
| `.github/workflows/ci.yml` | `[ main, develop ]` | `[ main, develop ]` |
| `.github/workflows/codeql.yml` | `[ main, develop ]` | `[ main, develop ]` |
| `.github/workflows/dependency-review.yml` | — | `[ main, develop ]` |
| `.github/workflows/docs.yml` | unchanged (main-only) | adds `- develop` |

`docs.yml` keeps `push.branches: [ main ]` because the `publish-docs` job gates on `github.event_name == 'push'` and pushes to GitHub Pages — Pages must stay main-only. `publish.yml` (Maven Central) is left untouched, also intentionally main-only.

No job step, action version, runner, permission, or concurrency group changed.

## Verification

Once this PR lands in develop, re-trigger checks on #190 by either closing+reopening it or pushing an empty commit; the `Build Android` / `Build Docs` / `Build iOS` jobs will then register and unblock the merge.

## Test plan

- [ ] `Build Android` runs on this PR (proves the trigger fix works for develop PRs).
- [ ] `Build Docs` runs.
- [ ] `Build iOS` runs (macOS runner).
- [ ] `CodeQL` Analyze Kotlin runs.
- [ ] `dependency-review` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)