### PR TITLE
Add develop branch to CI pipeline triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
   schedule:
     - cron: "0 0 * * 0"  # Every Sunday at midnight
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,16 @@ name: CodeQL
 on:
   push:
     branches: [ main, develop ]
+    paths-ignore:
+      - '.github/workflows/**'
+      - 'docs/**'
+      - '**/*.md'
   pull_request:
     branches: [ main, develop ]
+    paths-ignore:
+      - '.github/workflows/**'
+      - 'docs/**'
+      - '**/*.md'
   schedule:
     - cron: "0 0 * * 0"  # Every Sunday at midnight
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,13 +5,13 @@ on:
     branches:
       - main
       - develop
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
   pull_request:
     branches:
       - main
       - develop
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-*"
 
 permissions:
   contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
     branches:
       - main
+      - develop
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-*"
@@ -58,8 +60,8 @@ jobs:
     name: Publish to GitHub Pages
     runs-on: ubuntu-latest
     needs: build-docs
-    # Only publish on pushes to main or on release tags — not on PRs
-    if: github.event_name == 'push'
+    # Only publish on pushes to main or on release tags — not on PRs or develop
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-*"
     branches:
       - main
+      - develop
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Mirror `main` triggers onto `develop` for the new gitflow integration branch
- `ci.yml`, `codeql.yml`, `dependency-review.yml` now run on push/PR to `develop`
- `docs.yml` builds documentation on `develop` but publishes to GitHub Pages only from `main` or release tags
- `publish.yml` emits SNAPSHOT artifacts from both `main` and `develop`; tagged release publication remains tag-driven and untouched

## Test plan
- [ ] CI workflows trigger correctly on push to `develop`
- [ ] CI workflows trigger correctly on PRs targeting `develop`
- [ ] Documentation builds on `develop` push but is NOT published to GitHub Pages
- [ ] SNAPSHOT publication runs on push to `develop`
- [ ] Tagged release flow on `main` remains unaffected