### PR TITLE
Register enum converter for CheckoutVariant in sample

### DIFF
--- a/sample/android-app/build.gradle.kts
+++ b/sample/android-app/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(project(":sample:shared"))
     implementation(project(":featured-debug-ui"))
     implementation(project(":featured-platform"))
+    implementation(project(":providers:datastore"))
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.appcompat)
 }

--- a/sample/android-app/src/main/kotlin/dev/androidbroadcast/featured/sample/MainActivity.kt
+++ b/sample/android-app/src/main/kotlin/dev/androidbroadcast/featured/sample/MainActivity.kt
@@ -9,9 +9,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import dev.androidbroadcast.featured.CheckoutVariant
 import dev.androidbroadcast.featured.ConfigValues
 import dev.androidbroadcast.featured.SampleApp
+import dev.androidbroadcast.featured.datastore.DataStoreConfigValueProvider
+import dev.androidbroadcast.featured.datastore.registerConverter
 import dev.androidbroadcast.featured.debugui.FeatureFlagsDebugScreen
+import dev.androidbroadcast.featured.enumConverter
 import dev.androidbroadcast.featured.platform.defaultLocalProvider
 
 class MainActivity : ComponentActivity() {
@@ -19,7 +23,12 @@ class MainActivity : ComponentActivity() {
     // In production, move to Application or a DI singleton to avoid
     // recreating (and re-opening) the DataStore file on every rotation.
     private val configValues by lazy {
-        ConfigValues(localProvider = defaultLocalProvider(applicationContext))
+        val localProvider = defaultLocalProvider(applicationContext)
+        // DataStore only handles primitives natively; register a converter so that the
+        // enum-typed checkoutVariant flag can be persisted and observed without throwing.
+        (localProvider as? DataStoreConfigValueProvider)
+            ?.registerConverter(enumConverter<CheckoutVariant>())
+        ConfigValues(localProvider = localProvider)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/sample/android-app/src/main/kotlin/dev/androidbroadcast/featured/sample/MainActivity.kt
+++ b/sample/android-app/src/main/kotlin/dev/androidbroadcast/featured/sample/MainActivity.kt
@@ -17,12 +17,16 @@ import dev.androidbroadcast.featured.datastore.registerConverter
 import dev.androidbroadcast.featured.debugui.FeatureFlagsDebugScreen
 import dev.androidbroadcast.featured.enumConverter
 import dev.androidbroadcast.featured.platform.defaultLocalProvider
+import dev.androidbroadcast.featured.registerSampleFlags
 
 class MainActivity : ComponentActivity() {
     // ConfigValues is held at Activity scope for this sample.
     // In production, move to Application or a DI singleton to avoid
     // recreating (and re-opening) the DataStore file on every rotation.
     private val configValues by lazy {
+        // Populate FlagRegistry so FeatureFlagsDebugScreen can discover all flags via FlagRegistry.all().
+        registerSampleFlags()
+
         val localProvider = defaultLocalProvider(applicationContext)
         // DataStore only handles primitives natively; register a converter so that the
         // enum-typed checkoutVariant flag can be persisted and observed without throwing.

--- a/sample/shared/src/commonMain/kotlin/dev/androidbroadcast/featured/FeaturedSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/androidbroadcast/featured/FeaturedSample.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -51,6 +52,7 @@ public fun FeaturedSample(
     Column(
         modifier =
             modifier
+                .statusBarsPadding()
                 .padding(16.dp)
                 .fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/sample/shared/src/commonMain/kotlin/dev/androidbroadcast/featured/SampleApp.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/androidbroadcast/featured/SampleApp.kt
@@ -4,6 +4,22 @@ package dev.androidbroadcast.featured
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import dev.androidbroadcast.featured.registry.FlagRegistry
+
+/**
+ * Registers all [SampleFeatureFlags] with [FlagRegistry] so that [FeatureFlagsDebugScreen]
+ * can discover them via [FlagRegistry.all]. Call once on application start before opening
+ * the debug UI. Duplicate calls are safe — the registry ignores already-registered params.
+ */
+public fun registerSampleFlags() {
+    listOf(
+        SampleFeatureFlags.mainButtonRed,
+        SampleFeatureFlags.newFeatureSectionEnabled,
+        SampleFeatureFlags.newCheckout,
+        SampleFeatureFlags.promoBannerEnabled,
+        SampleFeatureFlags.checkoutVariant,
+    ).forEach(FlagRegistry::register)
+}
 
 /**
  * Root composable for the sample application.


### PR DESCRIPTION
## What crashed

`SampleFeatureFlags.checkoutVariant` is an enum-typed `ConfigParam<CheckoutVariant>` observed via `DataStoreConfigValueProvider`. DataStore's preferences API only supports six primitive types (String, Int, Long, Float, Double, Boolean). When `observe()` was called for the enum param, it fell through to `createPreferencesKey`, hit the `else` branch, and threw `IllegalArgumentException: Unsupported type: class dev.androidbroadcast.featured.CheckoutVariant`, crashing the process on launch.

## Fix

Register `enumConverter<CheckoutVariant>()` on the `DataStoreConfigValueProvider` instance before constructing `ConfigValues` in `MainActivity`. Since `defaultLocalProvider(context)` returns `LocalConfigValueProvider` (the interface), a safe cast to `DataStoreConfigValueProvider` is used to call `registerConverter`.

Also adds `implementation(project(":providers:datastore"))` to `sample/android-app/build.gradle.kts` — the `:providers:datastore` module is an `implementation` (not `api`) dependency of `:featured-platform`, so its symbols are not transitively visible to the app module.

## Scope

Sample-only patch. No library code is changed.

Library-level error handling (catching `IllegalArgumentException` in `observe()` so a missing converter fails gracefully rather than crashing) is tracked in the sibling PR `fix/configvalues-observe-catch`.