### PR TITLE
Document enum-flag converter requirement

### DIFF
--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/TypeConverter.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/TypeConverter.kt
@@ -50,6 +50,22 @@ public interface TypeConverter<T : Any> {
  * converter.fromString("UNKNOWN")   // throws IllegalArgumentException
  * ```
  *
+ * ## Compatible providers
+ *
+ * Pass the returned converter to `registerConverter` on any of these providers before the first
+ * read or write of an enum flag:
+ *
+ * - `DataStoreConfigValueProvider.registerConverter(enumConverter<T>())`
+ * - `JavaPreferencesConfigValueProvider.registerConverter(enumConverter<T>())`
+ * - `SharedPreferencesProviderConfig.registerConverter(enumConverter<T>())`
+ *
+ * `FirebaseConfigValueProvider` handles enums automatically via reflection — no registration
+ * is required.
+ *
+ * **iOS caveat:** `NSUserDefaultsConfigValueProvider` does not support enums at this time —
+ * it has no converter API. Use a `String` flag as a workaround on iOS and convert the raw
+ * value to your enum manually at the call site.
+ *
  * @param T The enum class to convert.
  * @return A [TypeConverter] that round-trips [T] by enum constant name.
  */

--- a/featured-gradle-plugin/README.md
+++ b/featured-gradle-plugin/README.md
@@ -1,0 +1,54 @@
+# featured-gradle-plugin
+
+Gradle plugin for the [Featured](../README.md) configuration management library.
+
+Apply it to a module and declare flags in the `featured { }` DSL block; the plugin generates
+typed `ConfigParam` objects, `ConfigValues` extension functions, and R8 shrinker rules.
+
+## Enum flags
+
+Declare an enum-typed flag with the `enum(...)` DSL function:
+
+```kotlin
+// build.gradle.kts
+featured {
+    localFlags {
+        enum(
+            key = "checkout_variant",
+            typeFqn = "com.example.CheckoutVariant",
+            default = "LEGACY",
+        )
+    }
+}
+```
+
+### Runtime converter requirement (Android / JVM)
+
+Storage-backed local providers serialize values as strings. Before the first read or write of
+an enum flag you must register an `enumConverter` on the provider, otherwise the provider
+throws `IllegalArgumentException` synchronously.
+
+Affected providers and the required registration call:
+
+| Provider | Registration |
+|---|---|
+| `DataStoreConfigValueProvider` | `provider.registerConverter(enumConverter<MyEnum>())` |
+| `JavaPreferencesConfigValueProvider` | `provider.registerConverter(enumConverter<MyEnum>())` |
+| `SharedPreferencesProviderConfig` | `provider.registerConverter(enumConverter<MyEnum>())` |
+
+`FirebaseConfigValueProvider` handles enums automatically via reflection — no registration
+is needed.
+
+```kotlin
+// Runtime wiring example (DataStore)
+val provider = DataStoreConfigValueProvider(dataStore).apply {
+    registerConverter(enumConverter<CheckoutVariant>())
+}
+val configValues = ConfigValues(localProvider = provider)
+```
+
+### iOS caveat
+
+`NSUserDefaultsConfigValueProvider` does not support enums at this time — it has no converter
+API. Use a `String` flag as a workaround on iOS and convert the raw value to your enum manually
+at the call site.

--- a/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/FlagContainer.kt
+++ b/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/FlagContainer.kt
@@ -84,8 +84,49 @@ public class FlagContainer {
     /**
      * Declares an enum-typed feature flag.
      *
-     * Enum flags are intentionally excluded from R8 `-assumevalues` DCE rules — the value
-     * cannot be assumed at build time (it is resolved at runtime from providers).
+     * The plugin generates a typed `ConfigParam<E>` backed by this declaration. Enum flags are
+     * intentionally excluded from R8 `-assumevalues` DCE rules — the value cannot be assumed at
+     * build time (it is resolved at runtime from providers).
+     *
+     * ## Runtime converter requirement (Android / JVM)
+     *
+     * Storage-backed local providers serialize values as strings and require an explicit
+     * [enumConverter] registration before the first read or write of this flag. Without it the
+     * provider throws [IllegalArgumentException] synchronously. Affected providers:
+     *
+     * - `DataStoreConfigValueProvider`
+     * - `JavaPreferencesConfigValueProvider`
+     * - `SharedPreferencesProviderConfig`
+     *
+     * Firebase Remote Config (`FirebaseConfigValueProvider`) handles enums automatically via
+     * reflection — no `registerConverter` call is needed there.
+     *
+     * **iOS caveat:** `NSUserDefaultsConfigValueProvider` does not support enums at this time —
+     * it has no converter API. Use a `String` flag as a workaround on iOS and convert the raw
+     * value to your enum manually at the call site.
+     *
+     * ## Example
+     *
+     * ```kotlin
+     * // Gradle DSL — declaration
+     * featured {
+     *     localFlags {
+     *         enum(
+     *             key = "checkout_variant",
+     *             typeFqn = "com.example.CheckoutVariant",
+     *             default = "LEGACY",
+     *         )
+     *     }
+     * }
+     * ```
+     *
+     * ```kotlin
+     * // Runtime — required wiring for non-Firebase local providers
+     * val provider = DataStoreConfigValueProvider(dataStore).apply {
+     *     registerConverter(enumConverter<CheckoutVariant>())
+     * }
+     * val configValues = ConfigValues(localProvider = provider)
+     * ```
      *
      * @param key The configuration key string (e.g. `"checkout_variant"`).
      * @param typeFqn The fully-qualified Kotlin class name of the enum (e.g. `"com.example.CheckoutVariant"`).


### PR DESCRIPTION
## Summary

Consumers who declare `enum(...)` flags in the `featured { }` DSL hit a silent crash
at first read/write on Android/JVM, and have no path forward on iOS, because neither
requirement was documented. This PR adds KDoc and a README section to surface both.

- **`FlagContainer.enum` KDoc** — explains that every storage-backed local provider
  (`DataStoreConfigValueProvider`, `JavaPreferencesConfigValueProvider`,
  `SharedPreferencesProviderConfig`) requires `registerConverter(enumConverter<T>())`
  before the first use; includes minimal Gradle DSL + runtime wiring examples.
- **`enumConverter` KDoc** — appends a "Compatible providers" section listing which
  providers accept the converter, notes Firebase is automatic, and surfaces the
  NSUserDefaults caveat.
- **`featured-gradle-plugin/README.md`** (new, minimal) — "Enum flags" section with a
  quick-reference table and the iOS workaround note.

No runtime code, type signatures, or ABI changed — `checkLegacyAbi` passes clean.

## Files touched

- `core/src/commonMain/kotlin/dev/androidbroadcast/featured/TypeConverter.kt`
- `featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/FlagContainer.kt`
- `featured-gradle-plugin/README.md` (new)

## Related branches

Part of a documentation + fix trio for the enum-flag gap:
- `fix/configvalues-observe-catch` — runtime fix
- `fix/sample-enum-converter` — sample app wiring fix
- `docs/enum-flag-registerconverter` — this PR

## Test plan

- [ ] `./gradlew :featured-gradle-plugin:compileKotlin` passes
- [ ] `./gradlew :core:compileKotlinMetadata` passes
- [ ] `./gradlew :core:checkLegacyAbi` passes (no ABI diff)
- [ ] `./gradlew spotlessCheck` passes
- [ ] `git diff` shows only KDoc and markdown lines changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)