### PR TITLE
chore: release 1.0.0 — Android-stable, docs restructure

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: github/codeql-action/init@v4
         with:
           languages: java-kotlin
+          build-mode: manual
 
       - name: Build for CodeQL
         # autobuild looks for 'testClasses' which doesn't exist in KMP; build manually instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.0.0] - 2026-05-30
 
 First stable release of Featured.
 
-Android is the primary stable target in this release — the public API for all
+Android is the primary stable target in this release — the Android-facing public API for all
 `dev.androidbroadcast.featured:*` artifacts published to Maven Central is covered
 by semantic versioning guarantees from this version onward.
 
 iOS (via KMP / SKIE) and JVM targets are included and functional, but API stability
 guarantees for those platforms will be formalised in a future minor release.
 
-See [[1.0.0-Beta1]](#100-beta1---2026-05-17) for the full list of features added in the initial release.
+See [1.0.0-Beta1] for the full list of features added in the initial release.
 
 ## [1.0.0-Beta1] - 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - 2026-05-30
+
+First stable release of Featured.
+
+Android is the primary stable target in this release — the public API for all
+`dev.androidbroadcast.featured:*` artifacts published to Maven Central is covered
+by semantic versioning guarantees from this version onward.
+
+iOS (via KMP / SKIE) and JVM targets are included and functional, but API stability
+guarantees for those platforms will be formalised in a future minor release.
+
+See [[1.0.0-Beta1]](#100-beta1---2026-05-17) for the full list of features added in the initial release.
 
 ## [1.0.0-Beta1] - 2026-05-17
 
@@ -84,5 +95,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - License mismatch: use MIT in all POM declarations (#174)
 - Stale artifact IDs in quick-start docs (#179)
 
-[Unreleased]: https://github.com/androidbroadcast/Featured/compare/v1.0.0-Beta1...HEAD
+[Unreleased]: https://github.com/androidbroadcast/Featured/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/androidbroadcast/Featured/compare/v1.0.0-Beta1...v1.0.0
 [1.0.0-Beta1]: https://github.com/androidbroadcast/Featured/releases/tag/v1.0.0-Beta1

--- a/docs/guides/android.md
+++ b/docs/guides/android.md
@@ -1,5 +1,8 @@
 # Android Integration Guide
 
+!!! success "Stable in 1.0"
+    The Android API is stable and covered by semantic versioning from version 1.0.0 onward.
+
 This guide walks you through integrating Featured into an Android project from scratch — from adding Gradle dependencies to using flags in a ViewModel with Compose and Firebase Remote Config.
 
 ## 1. Add Gradle dependencies

--- a/docs/guides/ios.md
+++ b/docs/guides/ios.md
@@ -1,5 +1,9 @@
 # iOS Integration Guide
 
+!!! warning "Preview"
+    iOS support is functional but API stability is not yet guaranteed.
+    Stable iOS support is planned for a future minor release.
+
 Featured exposes its Kotlin API to Swift via [SKIE](https://skie.touchlab.co/), which bridges coroutines, sealed classes, and default arguments automatically.
 
 ## 1. Swift Package Manager setup

--- a/docs/ios-integration.md
+++ b/docs/ios-integration.md
@@ -1,5 +1,9 @@
 # iOS Integration Guide: Swift Dead Code Elimination with #if
 
+!!! warning "Preview"
+    iOS support is functional but API stability is not yet guaranteed.
+    Stable iOS support is planned for a future minor release.
+
 This guide explains how to use the `featured-gradle-plugin` xcconfig output to eliminate
 disabled feature-flag code paths from your iOS Release binaries at compile time.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ android.r8.strictInputValidation=true
 android.proguard.failOnMissingFiles=true
 
 # Publishing
-VERSION_NAME=1.0.0-Beta1
+VERSION_NAME=1.0.0
 
 # Dokka
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Featured
-site_description: Type-safe, reactive feature-flag and configuration management for Kotlin Multiplatform
+site_description: Type-safe, reactive feature-flag and configuration management for Android (Kotlin Multiplatform)
 site_url: https://androidbroadcast.github.io/Featured/
 repo_name: AndroidBroadcast/Featured
 repo_url: https://github.com/AndroidBroadcast/Featured
@@ -32,7 +32,8 @@ theme:
     - content.tabs.link
 
 exclude_docs: |
-  superpowers/
+  cc-verification/
+  specs/
 
 plugins:
   - search
@@ -56,11 +57,13 @@ nav:
   - Getting Started: getting-started.md
   - Guides:
       - Android: guides/android.md
-      - iOS: guides/ios.md
       - JVM: guides/jvm.md
       - Providers: guides/providers.md
       - Best Practices: guides/best-practices.md
       - R8 DCE Verification: guides/r8-verification.md
-      - iOS Dead-Code Elimination: ios-integration.md
+      - Known Limitations: known-limitations.md
+  - iOS Preview:
+      - iOS Integration: guides/ios.md
+      - Swift Dead-Code Elimination: ios-integration.md
   - API Reference: api/index.md
   - Changelog: changelog.md


### PR DESCRIPTION
## Summary

- Bumps `VERSION_NAME` to `1.0.0`
- Adds `[1.0.0]` CHANGELOG entry declaring Android as the primary stable target (iOS/JVM functional but without API-stability guarantees until a future minor release)
- Fixes `mkdocs.yml` `exclude_docs` (was pointing to non-existent `superpowers/`; now correctly excludes `cc-verification/` and `specs/`)
- Adds `Known Limitations` page to the docs nav
- Moves iOS guides into a separate **"iOS Preview"** nav section — they no longer appear as peer documentation to the stable Android guide
- Adds **"Stable in 1.0"** admonition to the Android guide and **"Preview"** admonitions to both iOS guides
- Updates `site_description` to reflect Android-stable focus
- Updates CHANGELOG footer links for `[Unreleased]` and `[1.0.0]`

## Test plan

- [ ] `grep VERSION_NAME gradle.properties` → `1.0.0`
- [ ] `grep "\[1.0.0\]" CHANGELOG.md` → entry with today's date exists
- [ ] `mkdocs build --strict` passes (cc-verification/ and specs/ excluded, known-limitations in nav)
- [ ] Docs site nav: iOS pages appear under "iOS Preview", not under "Guides"
- [ ] After merge: tag `v1.0.0` and push → CI publishes to Maven Central + creates GitHub Release

https://claude.ai/code/session_01PCKtgT2ZS87NAtmPSjwSnE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCKtgT2ZS87NAtmPSjwSnE)_