### PR TITLE
ci(codeql): force Kotlin recompile so CodeQL sees source

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,10 @@ jobs:
           languages: java-kotlin
 
       - name: Build for CodeQL
-        # autobuild looks for 'testClasses' which doesn't exist in KMP; build manually instead
-        run: ./gradlew assembleDebug
+        # autobuild looks for 'testClasses' which doesn't exist in KMP; build manually instead.
+        # --no-build-cache + --rerun-tasks force Kotlin to actually recompile so the CodeQL
+        # tracer observes source. Without this, cached/up-to-date compile tasks are skipped and
+        # CodeQL fails with "no source code seen during build" (exit code 32).
+        run: ./gradlew assembleDebug --no-build-cache --rerun-tasks
 
       - uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Problem

The **Analyze Kotlin** (CodeQL) job fails with:

> CodeQL could not process any code written in Java/Kotlin … *no source code seen during build* (exit code 32)

The workflow replaces CodeQL autobuild (which looks for a non-existent `testClasses` task in this KMP project) with `./gradlew assembleDebug`. But with `gradle/actions/setup-gradle` restoring the Gradle cache, the Kotlin **compile tasks are served from cache or marked `UP-TO-DATE` and skipped** — so the CodeQL tracer observes zero source and the analysis aborts.

This is a workflow-configuration issue, independent of any source change; it surfaces on PRs whose diff doesn't force a recompile.

## Fix

Add `--no-build-cache --rerun-tasks` to the CodeQL build step:

```yaml
run: ./gradlew assembleDebug --no-build-cache --rerun-tasks
```

`--rerun-tasks` is the essential part — it ignores up-to-date checks and forces the Kotlin compile tasks to actually run, so the CodeQL tracer has source to analyze. `--no-build-cache` prevents the same outputs being pulled from the build cache.

This change is scoped to the CodeQL build step only; runtime/library behaviour is unaffected.

## Verification

Once CI runs on this PR, the **Analyze Kotlin** check should complete successfully instead of failing with exit code 32.

https://claude.ai/code/session_01LxuawhwkZuJAAoMkDpSTGZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxuawhwkZuJAAoMkDpSTGZ)_