### PR TITLE
Port shrinker DCE test (#217) and CodeQL fix (#218) to develop

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,9 +39,13 @@ jobs:
       - uses: github/codeql-action/init@v4
         with:
           languages: java-kotlin
+          build-mode: manual
 
       - name: Build for CodeQL
-        # autobuild looks for 'testClasses' which doesn't exist in KMP; build manually instead
-        run: ./gradlew assembleDebug
+        # autobuild looks for 'testClasses' which doesn't exist in KMP; build manually instead.
+        # --no-build-cache + --rerun-tasks force Kotlin to actually recompile so the CodeQL
+        # tracer observes source. Without this, cached/up-to-date compile tasks are skipped and
+        # CodeQL fails with "no source code seen during build" (exit code 32).
+        run: ./gradlew assembleDebug --no-build-cache --rerun-tasks
 
       - uses: github/codeql-action/analyze@v4

--- a/featured-shrinker-tests/src/test/kotlin/dev/androidbroadcast/featured/shrinker/assertions/JarAssertions.kt
+++ b/featured-shrinker-tests/src/test/kotlin/dev/androidbroadcast/featured/shrinker/assertions/JarAssertions.kt
@@ -1,7 +1,13 @@
 package dev.androidbroadcast.featured.shrinker.assertions
 
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.FieldVisitor
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
 import java.io.File
 import java.util.jar.JarFile
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -27,4 +33,87 @@ internal fun assertClassPresent(
             "Expected $internalName to survive R8 but it was not found in the output JAR",
         )
     }
+}
+
+/**
+ * Asserts that the bytecode of [ownerInternalName] in [jar] contains no reference to
+ * [referencedInternalName] — neither as a `NEW`/type reference nor as a method-call target.
+ *
+ * This proves that R8 actually constant-folded the flag and removed the dead branch's call
+ * site from the *caller*, as opposed to merely keeping the branch-target class alive. A test
+ * that only checked class presence would still pass if folding silently stopped working and
+ * the call site stayed reachable; this assertion closes that gap.
+ */
+internal fun assertClassDoesNotReference(
+    jar: File,
+    ownerInternalName: String,
+    referencedInternalName: String,
+) {
+    val classBytes =
+        JarFile(jar).use { jf ->
+            val entry =
+                assertNotNull(
+                    jf.getJarEntry("$ownerInternalName.class"),
+                    "Expected $ownerInternalName to be present in the output JAR",
+                )
+            jf.getInputStream(entry).use { it.readBytes() }
+        }
+
+    var referenced = false
+    val referencedType = "L$referencedInternalName;"
+    val detector =
+        object : ClassVisitor(Opcodes.ASM9) {
+            override fun visitMethod(
+                access: Int,
+                name: String?,
+                descriptor: String?,
+                signature: String?,
+                exceptions: Array<out String>?,
+            ): MethodVisitor =
+                object : MethodVisitor(Opcodes.ASM9) {
+                    override fun visitTypeInsn(
+                        opcode: Int,
+                        type: String?,
+                    ) {
+                        if (type == referencedInternalName) referenced = true
+                    }
+
+                    override fun visitMethodInsn(
+                        opcode: Int,
+                        owner: String?,
+                        name: String?,
+                        descriptor: String?,
+                        isInterface: Boolean,
+                    ) {
+                        if (owner == referencedInternalName) referenced = true
+                    }
+
+                    override fun visitFieldInsn(
+                        opcode: Int,
+                        owner: String?,
+                        name: String?,
+                        descriptor: String?,
+                    ) {
+                        if (owner == referencedInternalName) referenced = true
+                    }
+                }
+
+            override fun visitField(
+                access: Int,
+                name: String?,
+                descriptor: String?,
+                signature: String?,
+                value: Any?,
+            ): FieldVisitor? {
+                if (descriptor == referencedType) referenced = true
+                return null
+            }
+        }
+    ClassReader(classBytes).accept(detector, ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES)
+
+    assertFalse(
+        referenced,
+        "Expected $ownerInternalName to no longer reference $referencedInternalName after R8 " +
+            "folded the disabled branch, but a reference was found in its bytecode",
+    )
 }

--- a/featured-shrinker-tests/src/test/kotlin/dev/androidbroadcast/featured/shrinker/r8/R8BooleanFlagEliminationTest.kt
+++ b/featured-shrinker-tests/src/test/kotlin/dev/androidbroadcast/featured/shrinker/r8/R8BooleanFlagEliminationTest.kt
@@ -1,12 +1,14 @@
 package dev.androidbroadcast.featured.shrinker.r8
 
 import dev.androidbroadcast.featured.shrinker.assertions.assertClassAbsent
+import dev.androidbroadcast.featured.shrinker.assertions.assertClassDoesNotReference
 import dev.androidbroadcast.featured.shrinker.assertions.assertClassPresent
 import dev.androidbroadcast.featured.shrinker.bytecode.BIFURCATED_CALLER_INTERNAL
 import dev.androidbroadcast.featured.shrinker.bytecode.ELSE_BRANCH_CODE_INTERNAL
 import dev.androidbroadcast.featured.shrinker.bytecode.IF_BRANCH_CODE_INTERNAL
 import dev.androidbroadcast.featured.shrinker.harness.R8TestHarness
 import dev.androidbroadcast.featured.shrinker.rules.writeBooleanRules
+import dev.androidbroadcast.featured.shrinker.rules.writeBooleanRulesWithKeptDeadBranch
 import dev.androidbroadcast.featured.shrinker.rules.writeNoBooleanAssumeRules
 import kotlin.test.Test
 
@@ -93,5 +95,33 @@ internal class R8BooleanFlagEliminationTest : R8TestHarness() {
 
         assertClassPresent(outputJar, IF_BRANCH_CODE_INTERNAL)
         assertClassPresent(outputJar, ELSE_BRANCH_CODE_INTERNAL)
+    }
+
+    /**
+     * Regression guard for the consumer pitfall: a user-supplied `-keep` on a class that is
+     * only reachable through the disabled branch defeats dead-code elimination.
+     *
+     * The `-assumevalues … return false` rule is present and still works — R8 constant-folds
+     * the flag and drops the dead branch's call site, so runtime behaviour is unchanged. But
+     * `-keep class IfBranchCode { *; }` is an unconditional GC root, so the class itself can no
+     * longer be tree-shaken: it survives in the output even though nothing reaches it.
+     *
+     * This is the failure mode behind broad wildcard / `@Keep` rules silently inflating the
+     * APK. The control test above proves elimination normally happens; this test proves a
+     * `-keep` is what brings the dead class back.
+     *
+     * The final assertion pins the documented split between the two R8 phases: even though the
+     * class is kept, the `-assumevalues` rule must still have folded the disabled branch, so
+     * `BifurcatedCaller` must no longer reference `IfBranchCode`. Without this, the test would
+     * pass even if folding silently stopped working and the call site stayed reachable.
+     */
+    @Test
+    fun `dead-branch class survives when a user -keep rule pins it despite the assumevalues rule`() {
+        val outputJar = runBooleanR8 { writeBooleanRulesWithKeptDeadBranch(it) }
+
+        assertClassPresent(outputJar, IF_BRANCH_CODE_INTERNAL)
+        assertClassPresent(outputJar, ELSE_BRANCH_CODE_INTERNAL)
+        assertClassPresent(outputJar, BIFURCATED_CALLER_INTERNAL)
+        assertClassDoesNotReference(outputJar, BIFURCATED_CALLER_INTERNAL, IF_BRANCH_CODE_INTERNAL)
     }
 }

--- a/featured-shrinker-tests/src/test/kotlin/dev/androidbroadcast/featured/shrinker/rules/ProguardRulesWriter.kt
+++ b/featured-shrinker-tests/src/test/kotlin/dev/androidbroadcast/featured/shrinker/rules/ProguardRulesWriter.kt
@@ -50,6 +50,32 @@ internal fun writeBooleanRules(
 }
 
 /**
+ * Same `-assumevalues` block as [writeBooleanRules] with `returnValue = false`, but with an
+ * extra `-keep class … { *; }` on the **dead-branch** class ([IF_BRANCH_CODE_FQN]).
+ *
+ * This models a consumer that — deliberately or, far more commonly, via a broad wildcard or
+ * `@Keep` rule — pins a class that is only reachable through a disabled flag branch.
+ *
+ * The `-assumevalues` rule still lets R8 constant-fold the flag and drop the dead branch's
+ * *call site*, so behaviour is unchanged. But `-keep` is an unconditional GC root: the class
+ * itself can no longer be tree-shaken and survives in the output despite being unreachable,
+ * silently defeating the size benefit of build-time flags.
+ */
+internal fun writeBooleanRulesWithKeptDeadBranch(dest: File) {
+    dest.writeText(
+        """
+        -assumevalues class $BOOL_EXTENSIONS_FQN {
+            boolean $IS_DARK_MODE_ENABLED($CONFIG_VALUES_FQN) return false;
+        }
+        -keep class $BIFURCATED_CALLER_FQN { *; }
+        -keep class $IF_BRANCH_CODE_FQN { *; }
+        -keepclassmembers class $ELSE_BRANCH_CODE_FQN { public static int sideEffect; }
+        -dontwarn **
+        """.trimIndent(),
+    )
+}
+
+/**
  * No `-assumevalues` block — R8 cannot constant-fold the flag value.
  * The `-keepclassmembers` rules ensure the `sideEffect` field is not stripped
  * while the branch-target classes remain alive via reachability from the kept caller.


### PR DESCRIPTION
## Port #217 + #218 from main to develop

`main` had diverged from `develop` with three commits (a competing old-scope `release 1.0.0` plus two valuable fixes). This salvages the two valuable ones onto `develop`; the competing release commit (`405886f`) is intentionally discarded — `develop` already carries the correct redesign-scope 1.0.0 content and the Wiki docs migration (#193).

### Ported
- **#217** — `test(shrinker): cover -keep defeating flag DCE`. Adds `JarAssertions`, `ProguardRulesWriter` helper, and the `R8BooleanFlagEliminationTest` case modelling a consumer `-keep` rule that pins a flag-guarded class as a GC root (defeating tree-shaking while `-assumevalues` still folds the branch). Cherry-picked cleanly; compiles and passes against develop's redesigned shrinker module. Its `docs/guides/r8-verification.md` edit was dropped (that doc lives in the Wiki now).
- **#218** — CodeQL recompile fix. 3-way merge: keeps develop's `branches: [main, develop]` + `paths-ignore` triggers, adopts main's build-step fix (`build-mode: manual` + `assembleDebug --no-build-cache --rerun-tasks`) that prevents the "no source code seen during build" (exit 32) failure.

### Discarded (superseded by develop)
`405886f` VERSION_NAME / CHANGELOG / `docs/guides/*` restructure / `mkdocs.yml` — develop's release prep (#219) is the source of truth.

Prereq for the v1.0.0 release: once merged, develop becomes a superset of main's valuable content, unblocking the develop→main release merge.
