### PR TITLE
Publish Gradle plugin to Plugin Portal, keep Central listing clean

### DIFF
--- a/featured-gradle-plugin/build.gradle.kts
+++ b/featured-gradle-plugin/build.gradle.kts
@@ -1,7 +1,10 @@
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+
 plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.kotlinSerialization)
     `java-gradle-plugin`
+    alias(libs.plugins.pluginPublish)
     alias(libs.plugins.mavenPublish)
 }
 
@@ -13,14 +16,22 @@ kotlin {
 }
 
 gradlePlugin {
+    website.set("https://github.com/AndroidBroadcast/Featured")
+    vcsUrl.set("https://github.com/AndroidBroadcast/Featured")
     plugins {
         create("featured") {
             id = "dev.androidbroadcast.featured"
             implementationClass = "dev.androidbroadcast.featured.gradle.FeaturedPlugin"
+            displayName = "Featured Gradle Plugin"
+            description = "Gradle plugin for Featured – generates type-safe configuration flag declarations"
+            tags.set(listOf("featured", "feature-flags", "configuration", "codegen", "kotlin-multiplatform"))
         }
         create("featuredApplication") {
             id = "dev.androidbroadcast.featured.application"
             implementationClass = "dev.androidbroadcast.featured.gradle.FeaturedApplicationPlugin"
+            displayName = "Featured Application Gradle Plugin"
+            description = "Featured aggregator plugin – merges per-module flag manifests into a single generated registry"
+            tags.set(listOf("featured", "feature-flags", "configuration", "codegen", "kotlin-multiplatform"))
         }
     }
 }
@@ -56,6 +67,27 @@ mavenPublishing {
             connection.set("scm:git:git://github.com/AndroidBroadcast/Featured.git")
             developerConnection.set("scm:git:ssh://git@github.com/AndroidBroadcast/Featured.git")
         }
+    }
+}
+
+// The java-gradle-plugin marker artifacts (one per plugin id, the second under its own
+// groupId) are resolved via the Gradle Plugin Portal, where `publishPlugins` uploads them.
+// Vanniktech binds every MavenPublication — markers included — to the Maven Central
+// repository, which would pollute the Central listing with two stub marker artifacts.
+// Disable only the marker -> Central tasks so Central carries just the clean
+// `featured-gradle-plugin` impl jar (+ sources/javadoc/pom); the Portal still receives the
+// markers via `publishPlugins`, which uploads publications directly over HTTP independently
+// of these maven-publish repository tasks.
+//
+// Match on the task name (which Gradle fixes at registration time) rather than the task's
+// `repository`/`publication` properties: maven-publish wires those properties later, in an
+// afterEvaluate, so a `configureEach` action that reads them runs too early and sees them
+// unset. The name `publish<Pub>PublicationTo<Repo>Repository` is always correct here.
+// `publishPluginMavenPublication...` (the impl) ends with `PluginMavenPublication...`, not
+// `PluginMarkerMavenPublication...`, so it is intentionally left enabled.
+tasks.withType<PublishToMavenRepository>().configureEach {
+    if (name.endsWith("PluginMarkerMavenPublicationToMavenCentralRepository")) {
+        enabled = false
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ spotless = "8.4.0"
 ktlint = "1.8.0"
 turbine = "1.2.1"
 mavenPublish = "0.36.0"
+pluginPublish = "2.1.1"
 dokka = "2.2.0"
 detekt = "1.23.8"
 configcat = "5.1.0"
@@ -93,5 +94,6 @@ kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 skie = { id = "co.touchlab.skie", version.ref = "skie" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
+pluginPublish = { id = "com.gradle.plugin-publish", version.ref = "pluginPublish" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 androidKmpLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }


### PR DESCRIPTION
## Problem

On Maven Central the Gradle plugin showed up as multiple components, not a single clean library release:

- `dev.androidbroadcast.featured:featured-gradle-plugin` — the real impl jar (good)
- `dev.androidbroadcast.featured:dev.androidbroadcast.featured.gradle.plugin` — plugin **marker**
- `dev.androidbroadcast.featured.application:dev.androidbroadcast.featured.application.gradle.plugin` — second marker, under its own groupId

The marker artifacts are auto-generated by `java-gradle-plugin` (one per plugin id). Their coordinates are fixed by Gradle (`<id>:<id>.gradle.plugin`) and cannot be renamed. On Maven Central they polluted the listing and split the release across two groupId namespaces.

## Solution

Publish the plugin (and its markers) to the **Gradle Plugin Portal** — the conventional resolution channel for `plugins { id(...) version "..." }` — and keep Maven Central carrying **only** the clean `featured-gradle-plugin` impl jar (+ sources/javadoc/pom).

- Apply `com.gradle.plugin-publish` 2.1.1; add `website`/`vcsUrl` + per-plugin `displayName`/`description`/`tags`.
- Disable the marker→Central publish tasks so the two `*.gradle.plugin` stubs no longer reach Central; the Portal hosts them via `publishPlugins`.

### Why not the "canonical" Vanniktech platform switch

Vanniktech's `GradlePublishPlugin` platform is auto-selected when `com.gradle.plugin-publish` is applied, but in 0.36.0 its `configure()` is a **no-op** — it does not scope what goes to Central. Gradle's `maven-publish` still generates a `publish<Pub>PublicationToMavenCentralRepository` task for every publication, markers included. The Central bundle is built by walking the staging dir (`MavenCentralBuildService`), so a Central task with `enabled = false` never writes its files and the marker is absent from the bundle. Disabling those two tasks is therefore the correct, version-robust mechanism on 0.36 — not a workaround around a working platform.

## Verification

- `:featured-gradle-plugin:test` — **266/266 pass**
- `publishToMavenLocal` — BUILD SUCCESSFUL; impl carries jar + sources + javadoc + pom + module
- Central task predicate verified: exactly the two `…PluginMarkerMavenPublicationToMavenCentralRepository` tasks are disabled; `publishPluginMavenPublicationToMavenCentralRepository` (impl) stays enabled
- `publishPlugins` (Portal) task present
- `spotlessCheck` — pass

No network publish was performed.

## ⚠️ Required follow-up before the next release

Removing markers from Central means `plugins { id(...) }` now resolves **only** via the Gradle Plugin Portal. Before the next release the maintainer must:

1. Register both plugin ids on the Gradle Plugin Portal.
2. Add a `:featured-gradle-plugin:publishPlugins` step to the release workflow, gated on Portal credentials `gradle.publish.key` / `gradle.publish.secret` (`GRADLE_PUBLISH_KEY` / `GRADLE_PUBLISH_SECRET`).

Side benefit: the README `plugins {}` snippet now works out of the box via the default `gradlePluginPortal()`, whereas before it silently required `mavenCentral()` in `pluginManagement`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
