### PR TITLE
Wire Gradle Plugin Portal publishing for clean 1.0.0 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,16 @@ jobs:
         # release-pipeline debuggability (runs once per tag, CC savings are zero).
         run: ./gradlew --no-daemon publishToMavenCentral --no-configuration-cache
 
+      - name: Publish plugin to Gradle Plugin Portal
+        # Tag-only: the Portal rejects SNAPSHOT versions; branch pushes produce SNAPSHOTs.
+        # publishPlugins uploads directly — no manual promotion step unlike Maven Central.
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+          ORG_GRADLE_PROJECT_VERSION_NAME: ${{ steps.version.outputs.VERSION_NAME }}
+        run: ./gradlew --no-daemon :featured-gradle-plugin:publishPlugins --no-configuration-cache
+
   publish-xcframework:
     name: Publish XCFramework to GitHub Release
     # Only runs for version tags — not for SNAPSHOT pushes to main.

--- a/featured-gradle-plugin/build.gradle.kts
+++ b/featured-gradle-plugin/build.gradle.kts
@@ -1,7 +1,10 @@
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+
 plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.kotlinSerialization)
     `java-gradle-plugin`
+    alias(libs.plugins.pluginPublish)
     alias(libs.plugins.mavenPublish)
 }
 
@@ -13,14 +16,22 @@ kotlin {
 }
 
 gradlePlugin {
+    website.set("https://github.com/AndroidBroadcast/Featured")
+    vcsUrl.set("https://github.com/AndroidBroadcast/Featured")
     plugins {
         create("featured") {
             id = "dev.androidbroadcast.featured"
             implementationClass = "dev.androidbroadcast.featured.gradle.FeaturedPlugin"
+            displayName = "Featured Gradle Plugin"
+            description = "Gradle plugin for Featured – generates type-safe configuration flag declarations"
+            tags.set(listOf("featured", "feature-flags", "configuration", "codegen", "kotlin-multiplatform"))
         }
         create("featuredApplication") {
             id = "dev.androidbroadcast.featured.application"
             implementationClass = "dev.androidbroadcast.featured.gradle.FeaturedApplicationPlugin"
+            displayName = "Featured Application Gradle Plugin"
+            description = "Featured aggregator plugin – merges per-module flag manifests into a single generated registry"
+            tags.set(listOf("featured", "feature-flags", "configuration", "codegen", "kotlin-multiplatform"))
         }
     }
 }
@@ -56,6 +67,27 @@ mavenPublishing {
             connection.set("scm:git:git://github.com/AndroidBroadcast/Featured.git")
             developerConnection.set("scm:git:ssh://git@github.com/AndroidBroadcast/Featured.git")
         }
+    }
+}
+
+// The java-gradle-plugin marker artifacts (one per plugin id, the second under its own
+// groupId) are resolved via the Gradle Plugin Portal, where `publishPlugins` uploads them.
+// Vanniktech binds every MavenPublication — markers included — to the Maven Central
+// repository, which would pollute the Central listing with two stub marker artifacts.
+// Disable only the marker -> Central tasks so Central carries just the clean
+// `featured-gradle-plugin` impl jar (+ sources/javadoc/pom); the Portal still receives the
+// markers via `publishPlugins`, which uploads publications directly over HTTP independently
+// of these maven-publish repository tasks.
+//
+// Match on the task name (which Gradle fixes at registration time) rather than the task's
+// `repository`/`publication` properties: maven-publish wires those properties later, in an
+// afterEvaluate, so a `configureEach` action that reads them runs too early and sees them
+// unset. The name `publish<Pub>PublicationTo<Repo>Repository` is always correct here.
+// `publishPluginMavenPublication...` (the impl) ends with `PluginMavenPublication...`, not
+// `PluginMarkerMavenPublication...`, so it is intentionally left enabled.
+tasks.withType<PublishToMavenRepository>().configureEach {
+    if (name.endsWith("PluginMarkerMavenPublicationToMavenCentralRepository")) {
+        enabled = false
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ spotless = "8.4.0"
 ktlint = "1.8.0"
 turbine = "1.2.1"
 mavenPublish = "0.36.0"
+pluginPublish = "2.1.1"
 dokka = "2.2.0"
 detekt = "1.23.8"
 configcat = "5.1.0"
@@ -93,5 +94,6 @@ kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 skie = { id = "co.touchlab.skie", version.ref = "skie" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
+pluginPublish = { id = "com.gradle.plugin-publish", version.ref = "pluginPublish" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 androidKmpLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }


### PR DESCRIPTION
## Purpose

Bring the clean Gradle Plugin Portal publishing into the `main` release line so the **1.0.0** release publishes correctly:

- **#228 (ported):** Gradle plugin markers move off Maven Central to the Gradle Plugin Portal; Central carries only the clean `dev.androidbroadcast.featured:featured-gradle-plugin`.
- **CI:** `publish.yml` gains a tag-only `:featured-gradle-plugin:publishPlugins` step so a tagged release actually lands the plugin (and its markers) on the Plugin Portal. Without it, removing markers from Central would make `plugins { id(...) }` unresolvable.

`VERSION_NAME` stays `1.0.0` (no SNAPSHOT bump pulled in). Closes #229.

## After merge (release procedure)

1. Re-tag `v1.0.0` on the merged `main` HEAD (the existing tag predates these changes) and push → triggers `publish.yml`:
   - Maven Central: staged for manual promotion (existing behavior).
   - Gradle Plugin Portal: `publishPlugins` uploads directly (live; subject to first-time namespace approval for `dev.androidbroadcast`).
2. Promote the Central deployment in the Portal UI.
3. Verify `plugins { id("dev.androidbroadcast.featured") version "1.0.0" }` resolves via the default `gradlePluginPortal()`, and the Central listing shows a single `featured-gradle-plugin` artifact (no `*.gradle.plugin` markers).

Portal credentials `GRADLE_PUBLISH_KEY` / `GRADLE_PUBLISH_SECRET` are present in the `Main` environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
