### PR TITLE
Prepare v1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-06-03
+
+### Changed
+
+- Lowered the minimum supported JDK / JVM bytecode target from 21 to 17. Featured artifacts now target JVM 17, widening consumer compatibility — projects on JDK 17 toolchains can now consume the library. Consumers on newer JDKs are unaffected. (#233)
+- The Gradle plugin and its plugin marker artifact are now published to the Gradle Plugin Portal via a dedicated workflow; the Maven Central listing is kept free of plugin-marker artifacts. (#228, #231)
+
 ## [1.0.0] - 2026-05-30
 
 ### Removed
@@ -124,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - License mismatch: use MIT in all POM declarations (#174)
 - Stale artifact IDs in quick-start docs (#179)
 
-[Unreleased]: https://github.com/androidbroadcast/Featured/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/androidbroadcast/Featured/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/androidbroadcast/Featured/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/androidbroadcast/Featured/compare/v1.0.0-Beta1...v1.0.0
 [1.0.0-Beta1]: https://github.com/androidbroadcast/Featured/releases/tag/v1.0.0-Beta1

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ android.r8.strictInputValidation=true
 android.proguard.failOnMissingFiles=true
 
 # Publishing
-VERSION_NAME=1.1.0-SNAPSHOT
+VERSION_NAME=1.1.0
 
 # Dokka
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
## Summary

- `gradle.properties`: bump `VERSION_NAME` from `1.1.0-SNAPSHOT` to `1.1.0`
- `CHANGELOG.md`: add `[1.1.0] - 2026-06-03` section with two entries (JDK 17 downgrade #233, Plugin Portal publishing #228 #231); update footer comparison links (`[Unreleased]` now points to `v1.1.0...HEAD`, new `[1.1.0]` link added)
- `README.md`: no changes — all version references use `<version>` placeholders and there are no JDK/Java version requirements stated

## README check

Searched for hardcoded library versions (`1.0.0`) and JDK/Java 21 requirements — none found. README untouched.

## Not included

Do not merge — CI must pass first.