### PR TITLE
Back-merge v1.1.0 release and bump develop to 1.2.0-SNAPSHOT

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,8 @@ let package = Package(
         .binaryTarget(
             name: "FeaturedCore",
             // Updated automatically by CI on each release.
-            url: "https://github.com/AndroidBroadcast/Featured/releases/download/v1.0.0/FeaturedCore.xcframework.zip",
-            checksum: "e74984347e12aa67796d6ca7d30b1ac3104f697b3faf73703718e49045924a01"
+            url: "https://github.com/AndroidBroadcast/Featured/releases/download/v1.1.0/FeaturedCore.xcframework.zip",
+            checksum: "28b0d80da0bdce65eca3eafd4f836e4dcd49e10f2fcf7ea8c38eb8aa31e2be6f"
         ),
     ]
 )

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ android.r8.strictInputValidation=true
 android.proguard.failOnMissingFiles=true
 
 # Publishing
-VERSION_NAME=1.1.0
+VERSION_NAME=1.2.0-SNAPSHOT
 
 # Dokka
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
## What

Back-merges `main` into `develop` after the v1.1.0 release, then bumps the version to `1.2.0-SNAPSHOT`.

## Changes included

- **Package.swift** — URL updated to `v1.1.0` download, checksum updated to `28b0d80da0bdce65eca3eafd4f836e4dcd49e10f2fcf7ea8c38eb8aa31e2be6f` (post-tag commit `9cbd50a` on main)
- **gradle.properties** — `VERSION_NAME` bumped from `1.1.0` → `1.2.0-SNAPSHOT`

## How to merge

Squash-merge only (ruleset on `develop` forbids merge commits).