### PR TITLE
Auto-release to Maven Central on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,16 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}
           ORG_GRADLE_PROJECT_VERSION_NAME: ${{ steps.version.outputs.VERSION_NAME }}
-        # publishToMavenCentral = manual promotion (no auto-release); --no-configuration-cache for
-        # release-pipeline debuggability (runs once per tag, CC savings are zero).
-        run: ./gradlew --no-daemon publishToMavenCentral --no-configuration-cache
+        # On a version tag: pass -PmavenCentralAutomaticPublishing=true so the Vanniktech plugin
+        # releases the Central deployment automatically (no manual staging promote needed).
+        # On SNAPSHOT branch pushes: plain upload to the snapshots repo, no auto-release.
+        # --no-configuration-cache for release-pipeline debuggability (runs once per tag, CC savings are zero).
+        run: |
+          AUTO=""
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            AUTO="-PmavenCentralAutomaticPublishing=true"
+          fi
+          ./gradlew --no-daemon publishToMavenCentral $AUTO --no-configuration-cache
 
   publish-xcframework:
     name: Publish XCFramework to GitHub Release


### PR DESCRIPTION
## What changes

The `publish` job in `.github/workflows/publish.yml` now passes
`-PmavenCentralAutomaticPublishing=true` to Gradle when the trigger is a
version tag (`refs/tags/*`). On SNAPSHOT branch pushes (main/develop) the
flag is absent, so behaviour is unchanged: artifacts are uploaded to the
snapshots repository without any auto-release.

## Why no build.gradle.kts changes

`com.vanniktech.maven.publish` 0.36.0 reads `mavenCentralAutomaticPublishing`
as a Gradle property default for the `automaticRelease` parameter of
`publishToMavenCentral()`. All 15 modules already call
`publishToMavenCentral()` without arguments, so the property is the correct
single-point override — no per-module edits needed.

## Trade-off

The manual staging-promote gate in Central Portal is removed for release
builds. After a version tag push, artifacts will be released to Maven Central
automatically once the Gradle task completes. Ensure signing credentials and
Central credentials are correct before tagging.

## Files changed

- `.github/workflows/publish.yml` — only this file.