### PR TITLE
Release v1.1.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,16 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}
           ORG_GRADLE_PROJECT_VERSION_NAME: ${{ steps.version.outputs.VERSION_NAME }}
-        # publishToMavenCentral = manual promotion (no auto-release); --no-configuration-cache for
-        # release-pipeline debuggability (runs once per tag, CC savings are zero).
-        run: ./gradlew --no-daemon publishToMavenCentral --no-configuration-cache
+        # On a version tag: pass -PmavenCentralAutomaticPublishing=true so the Vanniktech plugin
+        # releases the Central deployment automatically (no manual staging promote needed).
+        # On SNAPSHOT branch pushes: plain upload to the snapshots repo, no auto-release.
+        # --no-configuration-cache for release-pipeline debuggability (runs once per tag, CC savings are zero).
+        run: |
+          AUTO=""
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            AUTO="-PmavenCentralAutomaticPublishing=true"
+          fi
+          ./gradlew --no-daemon publishToMavenCentral $AUTO --no-configuration-cache
 
   publish-xcframework:
     name: Publish XCFramework to GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-06-04
+
+### Fixed
+
+- Generated ProGuard `-assumevalues` rules are now registered as `consumerProguardFiles` for
+  `com.android.library` modules, ensuring rules are bundled into the AAR and applied by the
+  consuming app's R8. Previously the rules were wired only via `variant.proguardFiles`, which
+  has no effect in library modules and silently defeated dead-code elimination for flags
+  declared in library modules. (#240)
+- Flag descriptors are now wired to `ResolveFlagsTask` via a lazy `provider { }` instead of
+  an eager `afterEvaluate` block. Changing a flag's `default` value in `build.gradle.kts` now
+  correctly invalidates the build cache; previously the task could be served FROM-CACHE with
+  the old default, causing stale generated output. (#241)
+
+### Changed
+
+- Maven Central releases are now promoted automatically when triggered by a version tag; the
+  manual staging-promotion step in Sonatype Central Portal is no longer required. (#237)
+
 ## [1.1.0] - 2026-06-03
 
 ### Changed
@@ -131,7 +150,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - License mismatch: use MIT in all POM declarations (#174)
 - Stale artifact IDs in quick-start docs (#179)
 
-[Unreleased]: https://github.com/androidbroadcast/Featured/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/androidbroadcast/Featured/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/androidbroadcast/Featured/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/androidbroadcast/Featured/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/androidbroadcast/Featured/compare/v1.0.0-Beta1...v1.0.0
 [1.0.0-Beta1]: https://github.com/androidbroadcast/Featured/releases/tag/v1.0.0-Beta1

--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,8 @@ let package = Package(
         .binaryTarget(
             name: "FeaturedCore",
             // Updated automatically by CI on each release.
-            url: "https://github.com/AndroidBroadcast/Featured/releases/download/v1.0.0/FeaturedCore.xcframework.zip",
-            checksum: "e74984347e12aa67796d6ca7d30b1ac3104f697b3faf73703718e49045924a01"
+            url: "https://github.com/AndroidBroadcast/Featured/releases/download/v1.1.0/FeaturedCore.xcframework.zip",
+            checksum: "28b0d80da0bdce65eca3eafd4f836e4dcd49e10f2fcf7ea8c38eb8aa31e2be6f"
         ),
     ]
 )

--- a/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/AndroidProguardWiring.kt
+++ b/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/AndroidProguardWiring.kt
@@ -1,19 +1,20 @@
 package dev.androidbroadcast.featured.gradle
 
 import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.KotlinMultiplatformAndroidComponentsExtension
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
 
 /**
- * Wires the generated ProGuard rules file into every Android variant via the AGP Variant API.
+ * Wires the generated ProGuard rules file into every application variant via the AGP Variant API.
  *
- * Called lazily — only when `com.android.application` or `com.android.library` is present on
- * the project.
+ * Called lazily — only when `com.android.application` is present on the project.
  *
  * AGP 9.x does not propagate implicit Gradle task dependencies through [Variant.proguardFiles],
  * so [proguardTask] is also wired explicitly as a dependency of every `minify*WithR8` task.
  */
-internal fun wireProguardToVariants(
+internal fun wireProguardToApplicationVariants(
     project: Project,
     proguardTask: TaskProvider<GenerateProguardRulesTask>,
 ) {
@@ -29,6 +30,76 @@ internal fun wireProguardToVariants(
     // so we wire an explicit dependsOn on every R8 minify task.
     project.tasks.configureEach { task ->
         if (task.name.startsWith("minify") && task.name.endsWith("WithR8")) {
+            task.dependsOn(proguardTask)
+        }
+    }
+}
+
+/**
+ * Wires the generated ProGuard rules file as consumer ProGuard rules for every library variant.
+ *
+ * Called lazily — only when `com.android.library` is present on the project.
+ *
+ * Library modules do not run R8 themselves, so [Variant.proguardFiles] would never be applied.
+ * Consumer ProGuard rules are bundled into the AAR and forwarded to every consuming app's R8,
+ * which is where the `-assumevalues` rules need to run for flag dead-code elimination to work.
+ *
+ * AGP 9.x does not propagate implicit Gradle task dependencies through
+ * [LibraryVariant.consumerProguardFiles], so [proguardTask] is also wired explicitly as a
+ * dependency of every `export*ConsumerProguardFiles` task.
+ */
+internal fun wireProguardToLibraryVariants(
+    project: Project,
+    proguardTask: TaskProvider<GenerateProguardRulesTask>,
+) {
+    val libraryComponents =
+        project.extensions
+            .getByType(LibraryAndroidComponentsExtension::class.java)
+    libraryComponents.onVariants { variant ->
+        variant.consumerProguardFiles.add(
+            proguardTask.flatMap { it.outputFile },
+        )
+    }
+    // AGP 9.x does not propagate implicit task dependencies through
+    // variant.consumerProguardFiles, so we wire an explicit dependsOn on every
+    // export*ConsumerProguardFiles task (AGP's task for packaging consumer rules into the AAR).
+    project.tasks.configureEach { task ->
+        if (task.name.startsWith("export") && task.name.endsWith("ConsumerProguardFiles")) {
+            task.dependsOn(proguardTask)
+        }
+    }
+}
+
+/**
+ * Wires the generated ProGuard rules file as consumer ProGuard rules for every KMP Android
+ * library variant.
+ *
+ * Called lazily — only when `com.android.kotlin.multiplatform.library` is present on the project.
+ *
+ * KMP Android library modules register [KotlinMultiplatformAndroidComponentsExtension] instead
+ * of [LibraryAndroidComponentsExtension], so they require their own wiring function.
+ *
+ * Consumer ProGuard rules are bundled into the AAR and forwarded to every consuming app's R8,
+ * which is where the `-assumevalues` rules need to run for flag dead-code elimination to work.
+ *
+ * AGP 9.x does not propagate implicit Gradle task dependencies through
+ * [KotlinMultiplatformAndroidVariant.consumerProguardFiles], so [proguardTask] is also wired
+ * explicitly as a dependency of every `export*ConsumerProguardFiles` task.
+ */
+internal fun wireProguardToKmpLibraryVariants(
+    project: Project,
+    proguardTask: TaskProvider<GenerateProguardRulesTask>,
+) {
+    val kmpComponents =
+        project.extensions
+            .getByType(KotlinMultiplatformAndroidComponentsExtension::class.java)
+    kmpComponents.onVariants { variant ->
+        variant.consumerProguardFiles.add(
+            proguardTask.flatMap { it.outputFile },
+        )
+    }
+    project.tasks.configureEach { task ->
+        if (task.name.startsWith("export") && task.name.endsWith("ConsumerProguardFiles")) {
             task.dependsOn(proguardTask)
         }
     }

--- a/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/FeaturedPlugin.kt
+++ b/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/FeaturedPlugin.kt
@@ -61,10 +61,14 @@ public class FeaturedPlugin : Plugin<Project> {
         val manifestTask = registerManifestTask(target, resolveTask)
         registerFeaturedManifestConfiguration(target, manifestTask)
         wireToRootAggregator(target, resolveTask)
-        listOf("com.android.application", "com.android.library").forEach { pluginId ->
-            target.plugins.withId(pluginId) {
-                wireProguardToVariants(target, proguardTask)
-            }
+        target.plugins.withId("com.android.application") {
+            wireProguardToApplicationVariants(target, proguardTask)
+        }
+        target.plugins.withId("com.android.library") {
+            wireProguardToLibraryVariants(target, proguardTask)
+        }
+        target.plugins.withId("com.android.kotlin.multiplatform.library") {
+            wireProguardToKmpLibraryVariants(target, proguardTask)
         }
     }
 

--- a/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/FeaturedPlugin.kt
+++ b/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/FeaturedPlugin.kt
@@ -42,17 +42,7 @@ internal const val GENERATE_CONFIG_PARAM_TASK_NAME = "generateConfigParam"
 public class FeaturedPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         val extension = target.extensions.create("featured", FeaturedExtension::class.java)
-        val resolveTask = registerResolveFlagsTask(target)
-
-        // Wire DSL descriptors after the build script runs so the featured { } block is evaluated first.
-        // Calling afterEvaluate here (not inside the task config block) avoids IllegalMutationException
-        // when tasks are realized after project evaluation (e.g. in ProjectBuilder-based unit tests).
-        target.afterEvaluate {
-            resolveTask.configure { task ->
-                task.localFlagDescriptors.set(extension.localFlags.toDescriptors())
-                task.remoteFlagDescriptors.set(extension.remoteFlags.toDescriptors())
-            }
-        }
+        val resolveTask = registerResolveFlagsTask(target, extension)
 
         registerConfigParamTask(target, resolveTask)
         val proguardTask = registerProguardTask(target, resolveTask)
@@ -72,12 +62,20 @@ public class FeaturedPlugin : Plugin<Project> {
         }
     }
 
-    private fun registerResolveFlagsTask(target: Project): TaskProvider<ResolveFlagsTask> =
+    private fun registerResolveFlagsTask(
+        target: Project,
+        extension: FeaturedExtension,
+    ): TaskProvider<ResolveFlagsTask> =
         target.tasks.register(RESOLVE_FLAGS_TASK_NAME, ResolveFlagsTask::class.java) { task ->
             task.group = "featured"
             task.description = "Resolves feature flags declared in the featured { } DSL for '${target.path}'."
             task.moduleName.set(target.path)
             task.outputFile.set(target.layout.buildDirectory.file("featured/flags.txt"))
+            // Use lazy providers so the descriptors are evaluated after the build script's
+            // featured { } block has run. This ensures that changes to flag defaults are
+            // reflected in the task's @Input fingerprint and correctly invalidate the build cache.
+            task.localFlagDescriptors.set(target.provider { extension.localFlags.toDescriptors() })
+            task.remoteFlagDescriptors.set(target.provider { extension.remoteFlags.toDescriptors() })
         }
 
     private fun registerConfigParamTask(

--- a/featured-gradle-plugin/src/test/fixtures/android-library-project/build.gradle.kts
+++ b/featured-gradle-plugin/src/test/fixtures/android-library-project/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    id("com.android.library") version "9.1.0"
+    id("dev.androidbroadcast.featured")
+}
+
+android {
+    namespace = "dev.androidbroadcast.featured.testlib"
+    compileSdk = 36
+    defaultConfig { minSdk = 24 }
+}
+
+featured {
+    localFlags {
+        boolean("dark_mode", default = false)
+    }
+}

--- a/featured-gradle-plugin/src/test/fixtures/android-library-project/settings.gradle.kts
+++ b/featured-gradle-plugin/src/test/fixtures/android-library-project/settings.gradle.kts
@@ -1,0 +1,31 @@
+// The Featured plugin is injected via GradleRunner.withPluginClasspath(); AGP is resolved
+// from the Google Maven repository declared in pluginManagement below.
+pluginManagement {
+    repositories {
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    @Suppress("UnstableApiUsage")
+    repositories {
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+    }
+}
+
+rootProject.name = "android-library-project"

--- a/featured-gradle-plugin/src/test/fixtures/android-library-project/src/main/AndroidManifest.xml
+++ b/featured-gradle-plugin/src/test/fixtures/android-library-project/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/featured-gradle-plugin/src/test/kotlin/dev/androidbroadcast/featured/gradle/FeaturedPluginIntegrationTest.kt
+++ b/featured-gradle-plugin/src/test/kotlin/dev/androidbroadcast/featured/gradle/FeaturedPluginIntegrationTest.kt
@@ -1,5 +1,7 @@
 package dev.androidbroadcast.featured.gradle
 
+import dev.androidbroadcast.featured.gradle.manifest.androidSdkDirOrNull
+import dev.androidbroadcast.featured.gradle.manifest.copyManifestFixture
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assume.assumeTrue
@@ -33,17 +35,17 @@ class FeaturedPluginIntegrationTest {
 
     @Before
     fun setUp() {
-        val sdkDir = androidSdkDir()
+        val sdkDir = androidSdkDirOrNull()
         assumeTrue(
             "ANDROID_HOME or ANDROID_SDK_ROOT must be set to run integration tests",
             sdkDir != null,
         )
 
         projectDir = tempFolder.newFolder("android-project")
-        copyFixture(projectDir)
+        copyManifestFixture("android-project", projectDir)
 
         // Write local.properties with sdk.dir so AGP can locate the Android SDK.
-        projectDir.resolve("local.properties").writeText("sdk.dir=${sdkDir!!.absolutePath}\n")
+        projectDir.resolve("local.properties").writeText("sdk.dir=${sdkDir!!.invariantSeparatorsPath}\n")
     }
 
     // ── Tests ─────────────────────────────────────────────────────────────────
@@ -217,50 +219,6 @@ class FeaturedPluginIntegrationTest {
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
-
-    /** Returns the Android SDK directory from environment, or null if not set. */
-    private fun androidSdkDir(): File? {
-        val path =
-            System.getenv("ANDROID_HOME")?.takeIf { it.isNotBlank() }
-                ?: System.getenv("ANDROID_SDK_ROOT")?.takeIf { it.isNotBlank() }
-                ?: return null
-        return File(path).takeIf { it.isDirectory }
-    }
-
-    /**
-     * Copies the fixture project from `src/test/fixtures/android-project/` into [dest].
-     *
-     * The fixture is located relative to the plugin module's project directory, which
-     * Gradle TestKit passes as the working directory when running tests.
-     */
-    private fun copyFixture(dest: File) {
-        val fixtureSource = fixtureDir()
-        fixtureSource
-            .walkTopDown()
-            .filter { it.isFile }
-            .forEach { file ->
-                val relative = file.relativeTo(fixtureSource)
-                val target = dest.resolve(relative)
-                target.parentFile?.mkdirs()
-                file.copyTo(target, overwrite = true)
-            }
-    }
-
-    /**
-     * Resolves the fixture directory. The plugin module's project directory is either
-     * injected as the `user.dir` system property by Gradle's test task, or derived
-     * relative to this class file's location.
-     */
-    private fun fixtureDir(): File {
-        // Gradle's test task sets user.dir to the module project directory.
-        val moduleDir = File(System.getProperty("user.dir"))
-        val candidate = moduleDir.resolve("src/test/fixtures/android-project")
-        require(candidate.isDirectory) {
-            "Fixture directory not found at ${candidate.absolutePath}. " +
-                "Expected it relative to module project dir: ${moduleDir.absolutePath}"
-        }
-        return candidate
-    }
 
     /**
      * Creates a [GradleRunner] for the fixture project.

--- a/featured-gradle-plugin/src/test/kotlin/dev/androidbroadcast/featured/gradle/FeaturedPluginLibraryIntegrationTest.kt
+++ b/featured-gradle-plugin/src/test/kotlin/dev/androidbroadcast/featured/gradle/FeaturedPluginLibraryIntegrationTest.kt
@@ -1,0 +1,162 @@
+package dev.androidbroadcast.featured.gradle
+
+import dev.androidbroadcast.featured.gradle.manifest.androidSdkDirOrNull
+import dev.androidbroadcast.featured.gradle.manifest.copyManifestFixture
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end integration test that verifies the Featured Gradle plugin correctly wires
+ * generated `-assumevalues` rules as **consumer ProGuard rules** when applied to a
+ * `com.android.library` module.
+ *
+ * Library modules do not run R8 themselves. The rules must be registered as
+ * `consumerProguardFiles` so they are bundled into the AAR and forwarded to every
+ * consuming app's R8, enabling dead-code elimination of disabled flag branches.
+ *
+ * The test uses a minimal Android library fixture copied from
+ * `src/test/fixtures/android-library-project/`. It runs via Gradle TestKit with the plugin
+ * classpath injected automatically by the `java-gradle-plugin` metadata.
+ *
+ * Skipped when `ANDROID_HOME` / `ANDROID_SDK_ROOT` is not set — the test requires a
+ * real Android SDK to run AGP tasks.
+ */
+class FeaturedPluginLibraryIntegrationTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var projectDir: File
+
+    @Before
+    fun setUp() {
+        val sdkDir = androidSdkDirOrNull()
+        assumeTrue(
+            "ANDROID_HOME or ANDROID_SDK_ROOT must be set to run integration tests",
+            sdkDir != null,
+        )
+
+        projectDir = tempFolder.newFolder("android-library-project")
+        copyManifestFixture("android-library-project", projectDir)
+
+        projectDir.resolve("local.properties").writeText("sdk.dir=${sdkDir!!.invariantSeparatorsPath}\n")
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `generateFeaturedProguardRules task produces correct assumevalues rule for boolean local flag`() {
+        val result =
+            gradleRunner(projectDir)
+                .withArguments("generateFeaturedProguardRules", "--stacktrace")
+                .build()
+
+        val outcome = result.task(":generateFeaturedProguardRules")?.outcome
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            outcome,
+            "Expected :generateFeaturedProguardRules to succeed, got $outcome\n${result.output}",
+        )
+
+        val proFile = projectDir.resolve("build/featured/proguard-featured.pro")
+        assertTrue(proFile.exists(), "Expected proguard-featured.pro to be generated at ${proFile.path}")
+
+        assertContainsAssumevaluesBlock(proFile.readText())
+    }
+
+    @Test
+    fun `bundleRelease wires consumer proguard rules and completes successfully`() {
+        val result =
+            gradleRunner(projectDir)
+                .withArguments("bundleRelease", "--stacktrace")
+                .build()
+
+        // generateFeaturedProguardRules must have run as part of the library release build.
+        val proguardOutcome = result.task(":generateFeaturedProguardRules")?.outcome
+        assertTrue(
+            proguardOutcome == TaskOutcome.SUCCESS ||
+                proguardOutcome == TaskOutcome.UP_TO_DATE ||
+                proguardOutcome == TaskOutcome.FROM_CACHE,
+            "Expected :generateFeaturedProguardRules to participate in bundleRelease, got $proguardOutcome\n${result.output}",
+        )
+
+        val bundleOutcome = result.task(":bundleRelease")?.outcome
+        assertTrue(
+            bundleOutcome == TaskOutcome.SUCCESS || bundleOutcome == TaskOutcome.UP_TO_DATE,
+            "Expected :bundleRelease to succeed or be up-to-date, got $bundleOutcome\n${result.output}",
+        )
+
+        // Verify the generated rules appear in the AAR's consumer proguard intermediates.
+        // AGP writes consumer ProGuard rules to this path before packaging them in the AAR.
+        val consumerProguardDir = projectDir.resolve("build/intermediates/consumer_proguard_dir/release")
+        assertTrue(
+            consumerProguardDir.exists(),
+            "Expected consumer proguard intermediate dir to exist at ${consumerProguardDir.path}",
+        )
+
+        val consumerProguardFiles =
+            consumerProguardDir
+                .walkTopDown()
+                .filter { it.isFile && (it.name.endsWith(".pro") || it.name == "proguard.txt") }
+                .toList()
+        assertTrue(
+            consumerProguardFiles.isNotEmpty(),
+            "Expected at least one consumer proguard file (.pro or proguard.txt) under ${consumerProguardDir.path}",
+        )
+
+        val combinedContent = consumerProguardFiles.joinToString("\n") { it.readText() }
+        assertContainsAssumevaluesBlock(combinedContent)
+    }
+
+    // ── Assertions ────────────────────────────────────────────────────────────
+
+    /**
+     * Asserts that [content] contains a well-formed `-assumevalues` block for the root module's
+     * `dark_mode` boolean local flag.
+     *
+     * Expected output (from [ProguardRulesGenerator]):
+     * ```proguard
+     * -assumevalues class dev.androidbroadcast.featured.generated.GeneratedFlagExtensionsRootKt {
+     *     boolean isDarkModeEnabled(dev.androidbroadcast.featured.ConfigValues) return false;
+     * }
+     * ```
+     */
+    private fun assertContainsAssumevaluesBlock(content: String) {
+        assertTrue(
+            content.contains("-assumevalues class $EXTENSIONS_FQN {"),
+            "Expected -assumevalues block targeting $EXTENSIONS_FQN\nActual content:\n$content",
+        )
+        assertTrue(
+            content.contains("boolean $IS_DARK_MODE_ENABLED($CONFIG_VALUES_FQN) return false;"),
+            "Expected 'boolean $IS_DARK_MODE_ENABLED($CONFIG_VALUES_FQN) return false;' in rules\nActual content:\n$content",
+        )
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun gradleRunner(projectDir: File): GradleRunner =
+        GradleRunner
+            .create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .forwardOutput()
+
+    // ── Constants ─────────────────────────────────────────────────────────────
+
+    private companion object {
+        // The fixture is a single-project (root) build.
+        // modulePathToFileSuffix(":") → "Root" → fileName → "GeneratedFlagExtensionsRoot.kt"
+        // → JVM class: "GeneratedFlagExtensionsRootKt"
+        const val EXTENSIONS_FQN =
+            "dev.androidbroadcast.featured.generated.GeneratedFlagExtensionsRootKt"
+        const val CONFIG_VALUES_FQN = "dev.androidbroadcast.featured.ConfigValues"
+        const val IS_DARK_MODE_ENABLED = "isDarkModeEnabled"
+    }
+}

--- a/featured-gradle-plugin/src/test/kotlin/dev/androidbroadcast/featured/gradle/ResolveFlagsTaskCacheTest.kt
+++ b/featured-gradle-plugin/src/test/kotlin/dev/androidbroadcast/featured/gradle/ResolveFlagsTaskCacheTest.kt
@@ -1,0 +1,174 @@
+package dev.androidbroadcast.featured.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for issue #238: changing a flag's `default` value must invalidate the
+ * build cache for `resolveFeatureFlags` (and, transitively, all downstream generators).
+ *
+ * The test uses a minimal JVM fixture (no AGP / `ANDROID_HOME` required) and a local
+ * build-cache directory scoped to the `TemporaryFolder` so the cache lifecycle is fully
+ * controlled.
+ */
+class ResolveFlagsTaskCacheTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var projectDir: File
+    private lateinit var cacheDir: File
+
+    @Before
+    fun setUp() {
+        projectDir = tempFolder.newFolder("project")
+        cacheDir = tempFolder.newFolder("build-cache")
+        writeSettingsFile(projectDir, cacheDir)
+        writeBuildFile(projectDir, flagDefault = false)
+    }
+
+    @Test
+    fun `resolveFeatureFlags is not served from cache when a flag default changes`() {
+        // Run 1: cold cache → task executes and caches result.
+        val run1 =
+            gradleRunner(projectDir)
+                .withArguments(
+                    RESOLVE_FLAGS_TASK_NAME,
+                    "--build-cache",
+                    "--configuration-cache",
+                    "--configuration-cache-problems=warn",
+                ).build()
+
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            run1.task(":$RESOLVE_FLAGS_TASK_NAME")?.outcome,
+            "First run: expected SUCCESS.\n${run1.output}",
+        )
+        assertFlagsFileContains(projectDir, "my_flag|false|Boolean")
+
+        // Change the flag default from false → true.
+        writeBuildFile(projectDir, flagDefault = true)
+
+        // Run 2: build-cache populated; the task MUST re-execute because its @Input changed.
+        val run2 =
+            gradleRunner(projectDir)
+                .withArguments(
+                    RESOLVE_FLAGS_TASK_NAME,
+                    "--build-cache",
+                    "--configuration-cache",
+                    "--configuration-cache-problems=warn",
+                ).build()
+
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            run2.task(":$RESOLVE_FLAGS_TASK_NAME")?.outcome,
+            "Second run: expected SUCCESS (task should re-run because flag default changed).\n${run2.output}",
+        )
+        assertFlagsFileContains(projectDir, "my_flag|true|Boolean")
+    }
+
+    @Test
+    fun `resolveFeatureFlags is served from cache when nothing changes`() {
+        gradleRunner(projectDir)
+            .withArguments(
+                RESOLVE_FLAGS_TASK_NAME,
+                "--build-cache",
+                "--configuration-cache",
+                "--configuration-cache-problems=warn",
+            ).build()
+
+        // Delete the output so the task must use the cache (simulates `clean`).
+        projectDir.resolve("build").deleteRecursively()
+
+        val run2 =
+            gradleRunner(projectDir)
+                .withArguments(
+                    RESOLVE_FLAGS_TASK_NAME,
+                    "--build-cache",
+                    "--configuration-cache",
+                    "--configuration-cache-problems=warn",
+                ).build()
+
+        assertTrue(
+            run2.output.contains("Configuration cache entry reused") ||
+                run2.output.contains("Reusing configuration cache"),
+            "Second run should reuse the configuration cache.\n${run2.output}",
+        )
+        assertEquals(
+            TaskOutcome.FROM_CACHE,
+            run2.task(":$RESOLVE_FLAGS_TASK_NAME")?.outcome,
+            "Second run with unchanged inputs should be FROM_CACHE.\n${run2.output}",
+        )
+        assertFlagsFileContains(projectDir, "my_flag|false|Boolean")
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun writeSettingsFile(
+        projectDir: File,
+        cacheDir: File,
+    ) {
+        projectDir.resolve("settings.gradle.kts").writeText(
+            """
+            pluginManagement {
+                repositories {
+                    gradlePluginPortal()
+                    mavenCentral()
+                }
+            }
+            rootProject.name = "cache-test"
+            buildCache {
+                local {
+                    directory = "${cacheDir.absolutePath.replace("\\", "/")}"
+                    isEnabled = true
+                }
+            }
+            """.trimIndent(),
+        )
+    }
+
+    private fun writeBuildFile(
+        projectDir: File,
+        flagDefault: Boolean,
+    ) {
+        projectDir.resolve("build.gradle.kts").writeText(
+            """
+            plugins {
+                id("java-library")
+                id("dev.androidbroadcast.featured")
+            }
+            featured {
+                localFlags {
+                    boolean("my_flag", default = $flagDefault)
+                }
+            }
+            """.trimIndent(),
+        )
+    }
+
+    private fun assertFlagsFileContains(
+        projectDir: File,
+        expected: String,
+    ) {
+        val flagsFile = projectDir.resolve("build/featured/flags.txt")
+        assertTrue(flagsFile.exists(), "flags.txt must exist at ${flagsFile.path}")
+        val content = flagsFile.readText()
+        assertTrue(
+            content.contains(expected),
+            "Expected flags.txt to contain '$expected'.\nActual:\n$content",
+        )
+    }
+
+    private fun gradleRunner(projectDir: File): GradleRunner =
+        GradleRunner
+            .create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .forwardOutput()
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ android.r8.strictInputValidation=true
 android.proguard.failOnMissingFiles=true
 
 # Publishing
-VERSION_NAME=1.2.0-SNAPSHOT
+VERSION_NAME=1.1.1
 
 # Dokka
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ android.r8.strictInputValidation=true
 android.proguard.failOnMissingFiles=true
 
 # Publishing
-VERSION_NAME=1.1.0
+VERSION_NAME=1.2.0-SNAPSHOT
 
 # Dokka
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
## Release v1.1.1 — develop → main

### What's in 1.1.1

| PR | Change |
|----|--------|
| #240 | **fix:** ProGuard `-assumevalues` rules now registered as `consumerProguardFiles` for Android library modules — rules bundled into AAR and applied by the consuming app's R8 |
| #241 | **fix:** Flag descriptors wired lazily via `provider { }` — changing a flag's `default` in `build.gradle.kts` now correctly invalidates the build cache |
| #237 | **ci:** Maven Central auto-release on version tags (no manual Sonatype promotion needed) |

### After merge

1. Tag `v1.1.1` on the merge commit → `publish.yml` triggers Maven Central auto-release + XCFramework GitHub Release + `Package.swift` update; `publish-plugin-portal.yml` updates the Gradle Plugin Portal.
2. Back-merge `main → develop` and bump `VERSION_NAME` to `1.2.0-SNAPSHOT`.

### Merge method

Merge commit (preserve develop history on main, tag the merge commit).

https://claude.ai/code/session_011toF5AQD9AQtUzsZqTcCbd

---
_Generated by [Claude Code](https://claude.ai/code/session_011toF5AQD9AQtUzsZqTcCbd)_