### PR TITLE
ci: upload to Central Portal as USER_MANAGED, drop auto-release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,16 +48,11 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}
           ORG_GRADLE_PROJECT_VERSION_NAME: ${{ steps.version.outputs.VERSION_NAME }}
-        # On a version tag: pass -PmavenCentralAutomaticPublishing=true so the Vanniktech plugin
-        # releases the Central deployment automatically (no manual staging promote needed).
-        # On SNAPSHOT branch pushes: plain upload to the snapshots repo, no auto-release.
+        # On a version tag: uploads the deployment bundle to the Sonatype Central Portal as
+        # USER_MANAGED — the deployment must be promoted to release manually in the Portal UI.
+        # On SNAPSHOT branch pushes: uploads to the snapshots repo.
         # --no-configuration-cache for release-pipeline debuggability (runs once per tag, CC savings are zero).
-        run: |
-          AUTO=""
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            AUTO="-PmavenCentralAutomaticPublishing=true"
-          fi
-          ./gradlew --no-daemon publishToMavenCentral $AUTO --no-configuration-cache
+        run: ./gradlew --no-daemon publishToMavenCentral --no-configuration-cache
 
   publish-xcframework:
     name: Publish XCFramework to GitHub Release


### PR DESCRIPTION
## What
Disable automatic release to Maven Central. On a version tag the publish job now only **uploads** the deployment bundle to the Sonatype Central Portal (`USER_MANAGED`); the deployment must be **promoted to release manually** in the Portal UI.

## Why
`v1.1.1` tag publish failed with `403 Forbidden` on the `maven-central-build-service` upload while auto-release (`-PmavenCentralAutomaticPublishing=true`, first shipped via #237) was active — even though the Central Portal token is valid. Switching to `USER_MANAGED` removes the automatic release step and gives manual control over promotion.

## Change
- Drop `-PmavenCentralAutomaticPublishing=true` and its tag-conditional logic.
- `run:` is now just `./gradlew --no-daemon publishToMavenCentral --no-configuration-cache`.
- Comment updated; SNAPSHOT logic and the xcframework job untouched.

## Note
This does **not** retro-publish the existing `v1.1.1` tag (workflow re-run on the tag checks out the tag's old `publish.yml`). 1.1.1 Maven Central upload is handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)