### PR TITLE
ci: upload to Central Portal as USER_MANAGED, drop auto-release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,16 +48,11 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}
           ORG_GRADLE_PROJECT_VERSION_NAME: ${{ steps.version.outputs.VERSION_NAME }}
-        # On a version tag: pass -PmavenCentralAutomaticPublishing=true so the Vanniktech plugin
-        # releases the Central deployment automatically (no manual staging promote needed).
-        # On SNAPSHOT branch pushes: plain upload to the snapshots repo, no auto-release.
+        # On a version tag: uploads the deployment bundle to the Sonatype Central Portal as
+        # USER_MANAGED — the deployment must be promoted to release manually in the Portal UI.
+        # On SNAPSHOT branch pushes: uploads to the snapshots repo.
         # --no-configuration-cache for release-pipeline debuggability (runs once per tag, CC savings are zero).
-        run: |
-          AUTO=""
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            AUTO="-PmavenCentralAutomaticPublishing=true"
-          fi
-          ./gradlew --no-daemon publishToMavenCentral $AUTO --no-configuration-cache
+        run: ./gradlew --no-daemon publishToMavenCentral --no-configuration-cache
 
   publish-xcframework:
     name: Publish XCFramework to GitHub Release


### PR DESCRIPTION
Backport of #245 to `main`.

## Why on main
The `v1.1.1` tag points at a commit on `main` whose `publish.yml` still has `-PmavenCentralAutomaticPublishing=true`. Re-running Publish on the tag checks out the tag's workflow, so the fix must land on `main` before the tag is re-created. After merge, `v1.1.1` will be re-pointed at `main` HEAD to re-trigger Publish with USER_MANAGED upload.

## Change
Identical to #245: drop the auto-release flag and its tag-conditional logic; the publish step now only uploads the deployment to the Central Portal for manual promotion. Maven artifact contents are unchanged (release tree of 1.1.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)