### PR TITLE
Log provider errors to platform log by default

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -140,6 +140,9 @@ kover {
         filters {
             excludes {
                 classes("*Test*", "*Mock*", "*Fake*")
+                // Platform-specific logging actuals are not executable from JVM tests;
+                // logging is not business logic and does not need coverage measurement.
+                classes("dev.androidbroadcast.featured.LogProviderError*")
             }
         }
 

--- a/core/src/androidMain/kotlin/dev/androidbroadcast/featured/LogProviderError.kt
+++ b/core/src/androidMain/kotlin/dev/androidbroadcast/featured/LogProviderError.kt
@@ -1,0 +1,9 @@
+package dev.androidbroadcast.featured
+
+import android.util.Log
+
+private const val TAG = "Featured"
+
+internal actual fun logProviderError(e: Throwable) {
+    Log.w(TAG, "Provider error", e)
+}

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValues.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValues.kt
@@ -3,6 +3,7 @@
 
 package dev.androidbroadcast.featured
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.catch
@@ -80,7 +81,9 @@ import kotlin.concurrent.atomics.update
  * @param onProviderError Callback invoked whenever a provider throws during [getValue] or
  *   [observe]. Defaults to logging the error to the platform log (Android: `Log.w`,
  *   iOS: `NSLog`, JVM: `System.err`). Pass `{}` to silence errors; pass a custom handler
- *   to route them to your own observability system.
+ *   to route them to your own observability system. The callback should not throw; any
+ *   exception thrown by it is silently ignored to preserve the "errors never propagate
+ *   to callers" guarantee.
  * @throws IllegalArgumentException if both [localProvider] and [remoteProvider] are `null`.
  */
 public class ConfigValues(
@@ -109,6 +112,20 @@ public class ConfigValues(
      * are always consistent snapshots. Thread-safe on all KMP targets.
      */
     private val snapshot = AtomicReference<Map<String, ConfigValue<*>>>(emptyMap())
+
+    /**
+     * Forwards [error] to [onProviderError], swallowing any exception the handler itself throws.
+     *
+     * This ensures that a misbehaving error handler cannot break the read path — [getValue] and
+     * [observe] must remain safe for callers regardless of what [onProviderError] does.
+     */
+    private fun reportProviderError(error: Throwable) {
+        try {
+            onProviderError(error)
+        } catch (_: Throwable) {
+            // handler must not break the read path
+        }
+    }
 
     /** Writes [configValue] into the snapshot under [param]'s key (copy-on-write). */
     private fun <T : Any> writeSnapshot(
@@ -165,7 +182,10 @@ public class ConfigValues(
     public suspend fun <T : Any> getValue(param: ConfigParam<T>): ConfigValue<T> {
         val localValue =
             localProvider?.runCatching { get(param) }?.getOrElse { error ->
-                onProviderError(error)
+                // runCatching captures CancellationException — propagate it so coroutine
+                // cancellation is not silently swallowed as a provider error.
+                if (error is CancellationException) throw error
+                reportProviderError(error)
                 null
             }
         if (localValue != null) {
@@ -175,7 +195,8 @@ public class ConfigValues(
 
         val remoteValue =
             remoteProvider?.runCatching { get(param) }?.getOrElse { error ->
-                onProviderError(error)
+                if (error is CancellationException) throw error
+                reportProviderError(error)
                 null
             }
         if (remoteValue != null) {
@@ -297,8 +318,8 @@ public class ConfigValues(
      * @return A [Flow] of [ConfigValue] for the specified parameter.
      */
     public fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> {
-        val localFlow = localProvider?.observe(param)?.catch { e -> onProviderError(e) }
-        val remoteFlow = fetchSignal.map { getValue(param) }.catch { e -> onProviderError(e) }
+        val localFlow = localProvider?.observe(param)?.catch { e -> reportProviderError(e) }
+        val remoteFlow = fetchSignal.map { getValue(param) }.catch { e -> reportProviderError(e) }
 
         return flow<ConfigValue<T>> {
             emit(getValue(param))

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValues.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValues.kt
@@ -25,8 +25,8 @@ import kotlin.concurrent.atomics.update
  * At least one provider must be supplied; passing `null` for both throws [IllegalArgumentException].
  *
  * Provider calls inside [getValue] and [observe] are wrapped in try/catch. If a provider throws,
- * the error is reported to [onProviderError] (if set) and the next provider in the chain is tried.
- * This means [getValue] and [observe] never propagate provider exceptions to callers.
+ * the error is logged to the platform log by default via [onProviderError] and the next provider
+ * in the chain is tried. [getValue] and [observe] never propagate provider exceptions to callers.
  *
  * [fetch] is **not** guarded — the caller explicitly triggers a network operation and is
  * responsible for handling any exceptions it throws.
@@ -77,14 +77,16 @@ import kotlin.concurrent.atomics.update
  *
  * @param localProvider Optional provider for locally persisted overrides.
  * @param remoteProvider Optional provider for remote configuration values.
- * @param onProviderError Optional callback invoked whenever a provider throws during
- *   [getValue] or [observe]. Use this for logging or observability. Defaults to no-op.
+ * @param onProviderError Callback invoked whenever a provider throws during [getValue] or
+ *   [observe]. Defaults to logging the error to the platform log (Android: `Log.w`,
+ *   iOS: `NSLog`, JVM: `System.err`). Pass `{}` to silence errors; pass a custom handler
+ *   to route them to your own observability system.
  * @throws IllegalArgumentException if both [localProvider] and [remoteProvider] are `null`.
  */
 public class ConfigValues(
     private val localProvider: LocalConfigValueProvider? = null,
     private val remoteProvider: RemoteConfigValueProvider? = null,
-    private val onProviderError: (Throwable) -> Unit = {},
+    private val onProviderError: (Throwable) -> Unit = ::logProviderError,
 ) {
     init {
         require(localProvider != null || remoteProvider != null) {

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/LogProviderError.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/LogProviderError.kt
@@ -1,0 +1,12 @@
+package dev.androidbroadcast.featured
+
+/**
+ * Logs a provider error to the platform-appropriate log output.
+ *
+ * Called by [ConfigValues] when a provider throws during [ConfigValues.getValue] or
+ * [ConfigValues.observe]. Platform implementations:
+ * - **Android** — `android.util.Log.w`
+ * - **iOS** — `NSLog`
+ * - **JVM** — `System.err`
+ */
+internal expect fun logProviderError(e: Throwable)

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ProviderErrorHandlingTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ProviderErrorHandlingTest.kt
@@ -120,6 +120,22 @@ class ProviderErrorHandlingTest {
             assertEquals(false, errorCallbackInvoked)
         }
 
+    // --- default handler (logProviderError) does not throw ---
+
+    @Test
+    fun defaultHandlerDoesNotThrowWhenRemoteProviderFailsDuringObserve() =
+        runTest {
+            // ConfigValues constructed without an explicit onProviderError — the default
+            // platform-log handler must not propagate the exception to the caller.
+            val configValues = ConfigValues(remoteProvider = ThrowingRemoteProvider())
+            configValues.observe(testParam).test {
+                val emission = awaitItem()
+                assertEquals("default_value", emission.value)
+                assertEquals(ConfigValue.Source.DEFAULT, emission.source)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     // --- RED: observe() does not terminate on provider error ---
 
     @Test

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ProviderErrorHandlingTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ProviderErrorHandlingTest.kt
@@ -1,11 +1,14 @@
 package dev.androidbroadcast.featured
 
 import app.cash.turbine.test
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 
 class ProviderErrorHandlingTest {
     private val testParam = ConfigParam("test_key", "default_value")
@@ -187,5 +190,69 @@ class ProviderErrorHandlingTest {
 
                 cancelAndIgnoreRemainingEvents()
             }
+        }
+
+    // --- default handler (logProviderError) does not throw on getValue ---
+
+    @Test
+    fun defaultHandlerDoesNotThrowWhenRemoteProviderFailsDuringGetValue() =
+        runTest {
+            // ConfigValues without explicit onProviderError — the default platform-log handler
+            // must not propagate the exception out of getValue.
+            val configValues = ConfigValues(remoteProvider = ThrowingRemoteProvider())
+            val result = configValues.getValue(testParam)
+            assertEquals("default_value", result.value)
+            assertEquals(ConfigValue.Source.DEFAULT, result.source)
+        }
+
+    // --- throwing custom handler does not propagate through getValue or observe ---
+
+    @Test
+    fun throwingHandlerDoesNotPropagateOutOfGetValue() =
+        runTest {
+            val configValues =
+                ConfigValues(
+                    remoteProvider = ThrowingRemoteProvider(),
+                    onProviderError = { throw IllegalStateException("handler bug") },
+                )
+            // The handler throws but getValue must still return the default and not propagate.
+            val result = configValues.getValue(testParam)
+            assertEquals("default_value", result.value)
+            assertEquals(ConfigValue.Source.DEFAULT, result.source)
+        }
+
+    @Test
+    fun throwingHandlerDoesNotTerminateObserveFlow() =
+        runTest {
+            val configValues =
+                ConfigValues(
+                    remoteProvider = ThrowingRemoteProvider(),
+                    onProviderError = { throw IllegalStateException("handler bug") },
+                )
+            configValues.observe(testParam).test {
+                val emission = awaitItem()
+                // Flow emits default and does not crash despite the handler throwing.
+                assertEquals("default_value", emission.value)
+                assertEquals(ConfigValue.Source.DEFAULT, emission.source)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // --- CancellationException propagates and is not reported as a provider error ---
+
+    @Test
+    fun cancellationExceptionPropagatesOutOfGetValue() =
+        runTest {
+            val errorInvoked = mutableListOf<Throwable>()
+            val configValues =
+                ConfigValues(
+                    remoteProvider = ThrowingRemoteProvider(error = CancellationException("cancelled")),
+                    onProviderError = { errorInvoked.add(it) },
+                )
+            assertFailsWith<CancellationException> {
+                configValues.getValue(testParam)
+            }
+            // The handler must NOT have been called — CancellationException is not a provider error.
+            assertFalse(errorInvoked.isNotEmpty(), "onProviderError must not be invoked for CancellationException")
         }
 }

--- a/core/src/iosMain/kotlin/dev/androidbroadcast/featured/LogProviderError.kt
+++ b/core/src/iosMain/kotlin/dev/androidbroadcast/featured/LogProviderError.kt
@@ -3,5 +3,5 @@ package dev.androidbroadcast.featured
 import platform.Foundation.NSLog
 
 internal actual fun logProviderError(e: Throwable) {
-    NSLog("Featured: Provider error — %@", e.message ?: e.toString())
+    NSLog("Featured: Provider error — %@", e.stackTraceToString())
 }

--- a/core/src/iosMain/kotlin/dev/androidbroadcast/featured/LogProviderError.kt
+++ b/core/src/iosMain/kotlin/dev/androidbroadcast/featured/LogProviderError.kt
@@ -1,0 +1,7 @@
+package dev.androidbroadcast.featured
+
+import platform.Foundation.NSLog
+
+internal actual fun logProviderError(e: Throwable) {
+    NSLog("Featured: Provider error — %@", e.message ?: e.toString())
+}

--- a/core/src/jvmMain/kotlin/dev/androidbroadcast/featured/LogProviderError.kt
+++ b/core/src/jvmMain/kotlin/dev/androidbroadcast/featured/LogProviderError.kt
@@ -1,0 +1,6 @@
+package dev.androidbroadcast.featured
+
+internal actual fun logProviderError(e: Throwable) {
+    System.err.println("Featured: Provider error — ${e.message}")
+    e.printStackTrace(System.err)
+}

--- a/core/src/jvmMain/kotlin/dev/androidbroadcast/featured/LogProviderError.kt
+++ b/core/src/jvmMain/kotlin/dev/androidbroadcast/featured/LogProviderError.kt
@@ -1,6 +1,5 @@
 package dev.androidbroadcast.featured
 
 internal actual fun logProviderError(e: Throwable) {
-    System.err.println("Featured: Provider error — ${e.message}")
-    e.printStackTrace(System.err)
+    System.err.println("Featured: Provider error — ${e.stackTraceToString()}")
 }


### PR DESCRIPTION
Closes #250

## What
- `ConfigValues` default `onProviderError` changed from a silent no-op `{}` to platform logging via `internal expect fun logProviderError` (Android → `Log.w("Featured", …)`, iOS → `NSLog`, JVM → `System.err`, single atomic write with full stack trace).
- Hardening from review: `reportProviderError` guard — an exception thrown by a custom handler no longer terminates `observe()` flows or breaks `getValue()`; `CancellationException` is rethrown instead of being reported as a provider error.
- KDoc updated (class + param): default behavior, how to silence (`{}`), handler-must-not-throw note.
- Kover: `LogProviderError*` excluded from coverage (platform actuals unreachable from JVM tests; logging is not business logic). Gate stays ≥90% (97%+ actual).

## Behavioral note
Logging is unconditional (not debug-only): the library has no build-type notion at this level; pass `{}` to silence. This deviates intentionally from the issue's "debug builds" wording.

## Verification
- `:core:jvmTest` (4 new tests: default handler getValue/observe, throwing handler containment, CE propagation), `:core:koverVerify`, `spotlessCheck`, iOS/Android/JVM compile — all green.
- Full local `assemble` is affected by pre-existing #259 (iOS release link OOM, branch-independent); gate ran with release links excluded.
- Quality loop: finalize PASS (code-reviewer + simplify + pr-review-toolkit trio + build-engineer); acceptance VERIFIED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)