### PR TITLE
Unify observe emission contract across local providers

### DIFF
--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValues.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValues.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
@@ -416,26 +417,46 @@ public class ConfigValues(
     /**
      * Observes changes to the configuration value for the given parameter.
      *
-     * Emits the latest value immediately, then continues to emit updates whenever:
-     * - the value changes via the local provider, **or**
-     * - [fetch] completes and the remote provider returns a new value.
+     * Every emission is a **fully resolved value** obtained by calling [getValue], which applies
+     * the full priority chain: local provider → remote provider → [ConfigParam.defaultValue].
+     * Local-provider emissions are used **only as change signals** — their payloads are discarded
+     * and never re-emitted directly. This prevents a stale [ConfigValue.Source.DEFAULT] from
+     * the local provider (for an absent key) from clobbering a remote value already known to
+     * [getValue].
      *
-     * Note: local-provider direct emissions (i.e. direct calls to the provider's own `set`
-     * method, bypassing [ConfigValues.override]) reach observers reactively but do **not** write
-     * through to the snapshot. Use [ConfigValues.override] instead of the provider's `set` if
+     * The flow emits once immediately upon collection, then on every:
+     * - local-provider change signal (i.e. after [override] or direct provider [set] /
+     *   [resetOverride]), **or**
+     * - [fetch] completion.
+     *
+     * Consecutive identical resolved values are deduplicated via `distinctUntilChanged`.
+     *
+     * **Known cost:** each local-provider signal triggers one full [getValue] call. For
+     * whole-store providers (e.g. DataStore) any key change triggers a re-resolve for the
+     * observed parameter — reads are cheap and this is intentional and documented.
+     *
+     * Note: local-provider direct writes (bypassing [ConfigValues.override]) reach observers
+     * reactively but do **not** write through to the snapshot. Use [ConfigValues.override] if
      * [getValueCached] must reflect the write.
      *
      * @param param The configuration parameter to observe.
-     * @return A [Flow] of [ConfigValue] for the specified parameter.
+     * @return A [Flow] of fully resolved [ConfigValue] that never terminates on provider error.
      */
     public fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> {
-        val localFlow = localProvider?.observe(param)?.catch { e -> reportProviderError(e) }
-        val remoteFlow = fetchSignal.map { getValue(param) }.catch { e -> reportProviderError(e) }
+        // Local emissions are used only as signals — map payload to Unit to make intent explicit.
+        val localTrigger: Flow<Unit> =
+            localProvider
+                ?.observe(param)
+                ?.map { }
+                ?.catch { e -> reportProviderError(e) }
+                ?: emptyFlow()
+        val remoteTrigger: Flow<Unit> = fetchSignal
 
-        return flow<ConfigValue<T>> {
+        return flow {
             emit(getValue(param))
-            val merged = if (localFlow != null) merge(localFlow, remoteFlow) else remoteFlow
-            merged.collect { emit(it) }
+            merge(localTrigger, remoteTrigger).collect {
+                emit(getValue(param))
+            }
         }.distinctUntilChanged()
     }
 

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValues.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/ConfigValues.kt
@@ -7,14 +7,15 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.retryWhen
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.update
 
@@ -430,6 +431,8 @@ public class ConfigValues(
      * - [fetch] completion.
      *
      * Consecutive identical resolved values are deduplicated via `distinctUntilChanged`.
+     * Deduplication compares full [ConfigValue] equality — both value AND source must match for
+     * a frame to be suppressed.
      *
      * **Known cost:** each local-provider signal triggers one full [getValue] call. For
      * whole-store providers (e.g. DataStore) any key change triggers a re-resolve for the
@@ -448,7 +451,14 @@ public class ConfigValues(
             localProvider
                 ?.observe(param)
                 ?.map { }
-                ?.catch { e -> reportProviderError(e) }
+                // A third-party provider whose observe() throws must not permanently silence local
+                // change signals; bounded backoff avoids a hot loop. CancellationException is not
+                // caught by retryWhen — structured concurrency remains intact.
+                ?.retryWhen { cause, attempt ->
+                    reportProviderError(cause)
+                    delay(minOf(attempt + 1, 10) * 100L)
+                    true
+                }
                 ?: emptyFlow()
         val remoteTrigger: Flow<Unit> = fetchSignal
 

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProvider.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProvider.kt
@@ -1,5 +1,6 @@
 package dev.androidbroadcast.featured
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emitAll
@@ -103,7 +104,17 @@ public class InMemoryConfigValueProvider : LocalConfigValueProvider {
             emitAll(
                 changedKeyFlow
                     .filter { key -> key == param.key }
-                    .map { get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT) },
+                    .map {
+                        // Keep the observe stream alive on storage/converter errors; the error is
+                        // reported by the consumer's re-resolve via ConfigValues.getValue.
+                        try {
+                            get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
+                        } catch (ce: CancellationException) {
+                            throw ce
+                        } catch (_: Throwable) {
+                            ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
+                        }
+                    },
             )
         }
 }

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProvider.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProvider.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.map
 
 /**
  * A [LocalConfigValueProvider] that stores configuration overrides in memory.
@@ -83,8 +83,12 @@ public class InMemoryConfigValueProvider : LocalConfigValueProvider {
 
     /**
      * Returns a [kotlinx.coroutines.flow.Flow] that emits the current value for [param]
-     * immediately (if an override exists) and then emits again on every subsequent [set]
-     * or [resetOverride] call for the same key.
+     * immediately and then emits again on every subsequent [set] or [resetOverride] call
+     * for the same key.
+     *
+     * Conforms to [LocalConfigValueProvider.observe] contract: the initial emission is always
+     * present — [ConfigValue.Source.LOCAL] when a value is stored, [ConfigValue.Source.DEFAULT]
+     * wrapping [ConfigParam.defaultValue] otherwise.
      *
      * The flow completes only when the collector's scope is cancelled. It does **not** emit
      * after [clear] because [clear] does not signal individual key changes.
@@ -94,11 +98,12 @@ public class InMemoryConfigValueProvider : LocalConfigValueProvider {
      */
     override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
         flow {
-            get(param)?.let { emit(it) }
+            emit(get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT))
 
-            changedKeyFlow
-                .filter { key -> key == param.key }
-                .mapNotNull { get(param) }
-                .let { emitAll(it) }
+            emitAll(
+                changedKeyFlow
+                    .filter { key -> key == param.key }
+                    .map { get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT) },
+            )
         }
 }

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/LocalConfigValueProvider.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/LocalConfigValueProvider.kt
@@ -46,6 +46,25 @@ public interface LocalConfigValueProvider : ConfigValueProvider {
      * by the implementation via `distinctUntilChanged`, but the initial emission is always
      * guaranteed regardless of the current value.
      *
+     * **Lifetime contract:** the flow MUST never complete normally. It terminates only when the
+     * collector's coroutine scope is cancelled.
+     *
+     * **Error contract:** storage or converter errors MUST NOT terminate the flow. Emit a
+     * [ConfigValue] wrapping [ConfigParam.defaultValue] with [ConfigValue.Source.DEFAULT] as a
+     * fallback instead. The error is surfaced separately through [ConfigValues.observe] when it
+     * re-resolves via [ConfigValues.getValue] and calls [onProviderError][ConfigValues.onProviderError].
+     *
+     * **After [clear]:** behavior is implementation-defined. [InMemoryConfigValueProvider] does
+     * not emit after [clear] because [clear] does not signal individual key changes. Persistent
+     * providers backed by system storage (SharedPreferences, NSUserDefaults, DataStore) may or
+     * may not emit depending on whether their storage layer fires a change notification.
+     * Callers that need reliable reactive updates after a bulk clear should call [resetOverride]
+     * per parameter instead.
+     *
+     * **Payload:** the flow emits [ConfigValue]`<T>` rather than [Unit] so that consumers other
+     * than [ConfigValues] — such as custom observers that bypass the priority chain — can use the
+     * emitted value directly without an additional [get] call.
+     *
      * This contract enables [ConfigValues.observe] to use local emissions purely as change
      * signals and always perform a full priority-chain re-resolve via [ConfigValues.getValue],
      * which prevents stale DEFAULT values from clobbering a remote value that is already known.

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/LocalConfigValueProvider.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/LocalConfigValueProvider.kt
@@ -35,12 +35,27 @@ public interface LocalConfigValueProvider : ConfigValueProvider {
 
     /**
      * Observes changes to the configuration value for the given parameter.
-     * It emits the latest value immediately and then continues to emit updates
-     * whenever the value changes locally.
+     *
+     * **Emission contract:** the flow ALWAYS emits exactly one value immediately upon collection:
+     * - the locally stored [ConfigValue] with [ConfigValue.Source.LOCAL] if a value has been set, or
+     * - [ConfigValue] wrapping [ConfigParam.defaultValue] with [ConfigValue.Source.DEFAULT] if
+     *   no value is stored for [param].
+     *
+     * After the initial emission the flow continues to emit whenever the stored value changes
+     * (i.e. after [set] or [resetOverride]). Consecutive identical emissions MAY be deduplicated
+     * by the implementation via `distinctUntilChanged`, but the initial emission is always
+     * guaranteed regardless of the current value.
+     *
+     * This contract enables [ConfigValues.observe] to use local emissions purely as change
+     * signals and always perform a full priority-chain re-resolve via [ConfigValues.getValue],
+     * which prevents stale DEFAULT values from clobbering a remote value that is already known.
+     *
+     * [DataStoreConfigValueProvider][dev.androidbroadcast.featured.datastore.DataStoreConfigValueProvider]
+     * is the reference implementation that already conforms to this contract.
      *
      * @param param The configuration parameter to observe.
-     *
-     * @return A [kotlinx.coroutines.flow.Flow] of configuration values for the specified parameter.
+     * @return A [kotlinx.coroutines.flow.Flow] of [ConfigValue] snapshots that always emits
+     *   immediately on collection and then on every subsequent change.
      */
     public fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>>
 }

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ConfigValuesObserveContractTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ConfigValuesObserveContractTest.kt
@@ -1,0 +1,293 @@
+package dev.androidbroadcast.featured
+
+import app.cash.turbine.test
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Integration tests for [ConfigValues.observe] trigger-model contract.
+ *
+ * Each test asserts both the COUNT and ORDER of emitted frames, verifying that the
+ * trigger-model rewrite does not introduce spurious DEFAULT-sourced frames that would
+ * clobber already-known remote or local values.
+ *
+ * All test names use plain camelCase (no backticks) for Kotlin/Native compatibility.
+ */
+class ConfigValuesObserveContractTest {
+    // --- helpers ---
+
+    private class FakeRemoteProvider : RemoteConfigValueProvider {
+        private val storage = mutableMapOf<String, Any>()
+
+        fun set(
+            key: String,
+            value: Any,
+        ) {
+            storage[key] = value
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override suspend fun <T : Any> get(param: ConfigParam<T>): ConfigValue<T>? =
+            storage[param.key]?.let { value ->
+                ConfigValue(value as T, ConfigValue.Source.REMOTE)
+            }
+
+        override suspend fun fetch(activate: Boolean) = Unit
+    }
+
+    /**
+     * A [LocalConfigValueProvider] that emits on every key in its store, not just the observed
+     * key — simulating a whole-store provider such as DataStore.
+     */
+    private class WholeStoreLocalProvider : LocalConfigValueProvider {
+        private val storage = mutableMapOf<String, Any>()
+
+        // Emits the changed key name on every set/resetOverride.
+        private val changeSignal = MutableSharedFlow<String>(extraBufferCapacity = 1000)
+
+        @Suppress("UNCHECKED_CAST")
+        override suspend fun <T : Any> get(param: ConfigParam<T>): ConfigValue<T>? =
+            storage[param.key]?.let { v ->
+                ConfigValue(v as T, ConfigValue.Source.LOCAL)
+            }
+
+        override suspend fun <T : Any> set(
+            param: ConfigParam<T>,
+            value: T,
+        ) {
+            storage[param.key] = value
+            changeSignal.tryEmit(param.key)
+        }
+
+        override suspend fun <T : Any> resetOverride(param: ConfigParam<T>) {
+            storage.remove(param.key)
+            changeSignal.tryEmit(param.key)
+        }
+
+        override suspend fun clear() {
+            storage.clear()
+        }
+
+        /**
+         * Returns a Flow that ALWAYS emits on every key change — not filtered by [param].
+         * This simulates DataStore's behaviour where a write to any preference triggers an
+         * emission of the full preferences snapshot.
+         */
+        override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
+            changeSignal.map {
+                get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
+            }
+    }
+
+    // --- test cases ---
+
+    /**
+     * (a) When local has no value and remote has one, the initial frame is REMOTE.
+     * No intermediate DEFAULT frame should appear between collection and the REMOTE frame.
+     */
+    @Test
+    fun observeEmitsRemoteInitially_whenLocalHasNoKeyAndRemoteHasValue() =
+        runTest {
+            val remote = FakeRemoteProvider().also { it.set("flag", "remote_val") }
+            val configValues =
+                ConfigValues(
+                    localProvider = InMemoryConfigValueProvider(),
+                    remoteProvider = remote,
+                )
+            val param = ConfigParam("flag", "default_val")
+
+            configValues.observe(param).test {
+                val first = awaitItem()
+                assertEquals("remote_val", first.value)
+                assertEquals(ConfigValue.Source.REMOTE, first.source)
+                // No additional DEFAULT frame follows the REMOTE frame.
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    /**
+     * (b) override → resetOverride → the observer converges to REMOTE without emitting DEFAULT
+     * while remote value is still present.
+     *
+     * Frame sequence: REMOTE (initial) → LOCAL (after override) → REMOTE (after resetOverride)
+     * No DEFAULT frame should appear between LOCAL and REMOTE.
+     */
+    @Test
+    fun observeConvergesToRemote_afterOverrideAndReset_withoutDefaultFlicker() =
+        runTest {
+            val remote = FakeRemoteProvider().also { it.set("flag", "remote_val") }
+            val local = InMemoryConfigValueProvider()
+            val configValues =
+                ConfigValues(
+                    localProvider = local,
+                    remoteProvider = remote,
+                )
+            val param = ConfigParam("flag", "default_val")
+
+            configValues.observe(param).test {
+                // Initial: remote value
+                val first = awaitItem()
+                assertEquals("remote_val", first.value)
+                assertEquals(ConfigValue.Source.REMOTE, first.source)
+
+                // Override with local value
+                configValues.override(param, "local_val")
+                val afterOverride = awaitItem()
+                assertEquals("local_val", afterOverride.value)
+                assertEquals(ConfigValue.Source.LOCAL, afterOverride.source)
+
+                // Reset override — observer should resolve back to REMOTE
+                configValues.resetOverride(param)
+                val afterReset = awaitItem()
+                assertEquals("remote_val", afterReset.value)
+                // Must NOT be DEFAULT (remote value is still present)
+                assertNotEquals(ConfigValue.Source.DEFAULT, afterReset.source)
+                assertEquals(ConfigValue.Source.REMOTE, afterReset.source)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    /**
+     * (c) No remote provider: initial frame is DEFAULT; after override emits LOCAL.
+     *
+     * Frame sequence: DEFAULT → LOCAL
+     */
+    @Test
+    fun observeEmitsDefault_thenLocal_whenNoRemoteProvider() =
+        runTest {
+            val local = InMemoryConfigValueProvider()
+            val configValues = ConfigValues(localProvider = local)
+            val param = ConfigParam("flag", "my_default")
+
+            configValues.observe(param).test {
+                val first = awaitItem()
+                assertEquals("my_default", first.value)
+                assertEquals(ConfigValue.Source.DEFAULT, first.source)
+
+                local.set(param, "local_val")
+                val afterSet = awaitItem()
+                assertEquals("local_val", afterSet.value)
+                assertEquals(ConfigValue.Source.LOCAL, afterSet.source)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    /**
+     * (d) Mid-stream race: remote value becomes available via fetch() after the observer has
+     * already started. No regression to DEFAULT must occur after the REMOTE frame is emitted.
+     *
+     * Acceptable sequences:
+     *   DEFAULT → REMOTE  (most common path)
+     *   REMOTE             (if getValue() races with fetch() and wins)
+     *
+     * Invariant: no DEFAULT frame may appear AFTER a REMOTE frame.
+     */
+    @Test
+    fun observeDoesNotRegressToDefault_afterRemoteBecomesAvailableViaMidStreamFetch() =
+        runTest {
+            val remote = FakeRemoteProvider() // no value yet
+            val configValues =
+                ConfigValues(
+                    localProvider = InMemoryConfigValueProvider(),
+                    remoteProvider = remote,
+                )
+            val param = ConfigParam("flag", "default_val")
+
+            configValues.observe(param).test {
+                val first = awaitItem()
+                // Remote has no value yet; first frame must be DEFAULT
+                assertEquals("default_val", first.value)
+                assertEquals(ConfigValue.Source.DEFAULT, first.source)
+
+                // Now remote becomes available and fetch() is called
+                remote.set("flag", "remote_val")
+                configValues.fetch()
+
+                val afterFetch = awaitItem()
+                assertEquals("remote_val", afterFetch.value)
+                assertEquals(ConfigValue.Source.REMOTE, afterFetch.source)
+
+                // No further events (no DEFAULT regression)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    /**
+     * (e) Whole-store provider simulation: writing an UNRELATED key must not produce an extra
+     * distinct frame for the observed parameter.
+     *
+     * The WholeStoreLocalProvider emits on every write regardless of key. The trigger-model
+     * re-resolve will call getValue() and get the same value back — distinctUntilChanged must
+     * suppress the duplicate.
+     */
+    @Test
+    fun observeDoesNotEmitExtraFrame_whenUnrelatedKeyChangesInWholeStoreProvider() =
+        runTest {
+            val local = WholeStoreLocalProvider()
+            val configValues = ConfigValues(localProvider = local)
+            val observedParam = ConfigParam("observed_flag", "default_obs")
+            val unrelatedParam = ConfigParam("other_flag", "default_other")
+
+            // Pre-set the observed param so the initial frame is LOCAL
+            local.set(observedParam, "obs_val")
+
+            configValues.observe(observedParam).test {
+                val first = awaitItem()
+                assertEquals("obs_val", first.value)
+                assertEquals(ConfigValue.Source.LOCAL, first.source)
+
+                // Change unrelated key — whole-store provider fires for all keys
+                local.set(unrelatedParam, "other_val")
+
+                // Must NOT produce another frame for observed_flag (distinctUntilChanged)
+                expectNoEvents()
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    /**
+     * (f) warmUp + active observe + fetch: values are correct and no DEFAULT regression occurs
+     * after fetch() when a remote value exists.
+     *
+     * Frame sequence: REMOTE (initial after warmUp) → REMOTE (after fetch)
+     * No DEFAULT frame between them.
+     */
+    @Test
+    fun observeRemainsCorrect_afterWarmUpAndFetch_withNoDefaultRegression() =
+        runTest {
+            val remote = FakeRemoteProvider().also { it.set("flag", "remote_v1") }
+            val configValues =
+                ConfigValues(
+                    localProvider = InMemoryConfigValueProvider(),
+                    remoteProvider = remote,
+                )
+            val param = ConfigParam("flag", "default_val")
+
+            configValues.warmUp(listOf(param))
+
+            configValues.observe(param).test {
+                val first = awaitItem()
+                assertEquals("remote_v1", first.value)
+                assertEquals(ConfigValue.Source.REMOTE, first.source)
+
+                // Update remote and fetch
+                remote.set("flag", "remote_v2")
+                configValues.fetch()
+
+                val afterFetch = awaitItem()
+                assertEquals("remote_v2", afterFetch.value)
+                assertEquals(ConfigValue.Source.REMOTE, afterFetch.source)
+
+                // No DEFAULT regression frame
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+}

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ConfigValuesObserveContractTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ConfigValuesObserveContractTest.kt
@@ -3,12 +3,14 @@ package dev.androidbroadcast.featured
 import app.cash.turbine.test
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 
 /**
  * Integration tests for [ConfigValues.observe] trigger-model contract.
@@ -292,6 +294,275 @@ class ConfigValuesObserveContractTest {
                 assertEquals(ConfigValue.Source.REMOTE, afterFetch.source)
 
                 // No DEFAULT regression frame
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // --- error robustness contract ---
+
+    /**
+     * A [LocalConfigValueProvider] whose observe() flow emits a change signal but whose
+     * get() throws on demand. Allows simulating a provider that fails mid-stream.
+     *
+     * [setGetShouldThrow] controls whether get() throws on the next call. After a throw the
+     * flag resets to false so the provider "recovers" on subsequent calls.
+     */
+    private class FailingGetLocalProvider : LocalConfigValueProvider {
+        private val storage = mutableMapOf<String, Any>()
+        private val changeSignal = MutableSharedFlow<String>(extraBufferCapacity = 1000)
+        var setGetShouldThrow = false
+
+        @Suppress("UNCHECKED_CAST")
+        override suspend fun <T : Any> get(param: ConfigParam<T>): ConfigValue<T>? {
+            if (setGetShouldThrow) {
+                setGetShouldThrow = false
+                throw RuntimeException("simulated storage error")
+            }
+            return storage[param.key]?.let { ConfigValue(it as T, ConfigValue.Source.LOCAL) }
+        }
+
+        override suspend fun <T : Any> set(
+            param: ConfigParam<T>,
+            value: T,
+        ) {
+            storage[param.key] = value
+            changeSignal.tryEmit(param.key)
+        }
+
+        override suspend fun <T : Any> resetOverride(param: ConfigParam<T>) {
+            storage.remove(param.key)
+            changeSignal.tryEmit(param.key)
+        }
+
+        override suspend fun clear() {
+            storage.clear()
+        }
+
+        override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
+            changeSignal
+                .map {
+                    try {
+                        get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
+                    } catch (e: RuntimeException) {
+                        ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
+                    }
+                }.onStart { emit(get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)) }
+
+        /** Triggers a change signal WITHOUT updating storage — simulates a spurious fire. */
+        fun triggerSignalFor(key: String) {
+            changeSignal.tryEmit(key)
+        }
+    }
+
+    /**
+     * G1: localProvider == null → initial emit works and fetch() re-resolve works.
+     * ConfigValues must be constructable with only a remote provider.
+     */
+    @Test
+    fun observeEmitsCorrectly_whenLocalProviderIsNull() =
+        runTest {
+            val remote = FakeRemoteProvider().also { it.set("flag", "remote_val") }
+            val configValues = ConfigValues(remoteProvider = remote)
+            val param = ConfigParam("flag", "default_val")
+
+            configValues.observe(param).test {
+                val first = awaitItem()
+                assertEquals("remote_val", first.value)
+                assertEquals(ConfigValue.Source.REMOTE, first.source)
+
+                // fetch() re-resolve still works
+                remote.set("flag", "remote_v2")
+                configValues.fetch()
+                val afterFetch = awaitItem()
+                assertEquals("remote_v2", afterFetch.value)
+                assertEquals(ConfigValue.Source.REMOTE, afterFetch.source)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    /**
+     * G6: provider observe() returns a Flow that throws transiently on first collection, then
+     * recovers → ConfigValues.observe still emits the initial frame (getValue() is independent of
+     * localTrigger), retryWhen keeps localTrigger alive, and subsequent set() calls are delivered.
+     *
+     * The recovered provider delivers the set() emission once retryWhen re-subscribes successfully.
+     */
+    @Test
+    fun observeDeliversSubsequentChanges_afterLocalProviderFlowThrowsTransiently() =
+        runTest {
+            val collectedErrors = mutableListOf<Throwable>()
+            val signal = MutableSharedFlow<String>(extraBufferCapacity = 1000)
+            val storage = mutableMapOf<String, Any>()
+            // Controls whether the next collection of the flow throws. Resets to false after throw.
+            var shouldThrowOnCollection = true
+
+            val faultyProvider =
+                object : LocalConfigValueProvider {
+                    @Suppress("UNCHECKED_CAST")
+                    override suspend fun <T : Any> get(param: ConfigParam<T>): ConfigValue<T>? =
+                        storage[param.key]?.let { ConfigValue(it as T, ConfigValue.Source.LOCAL) }
+
+                    override suspend fun <T : Any> set(
+                        param: ConfigParam<T>,
+                        value: T,
+                    ) {
+                        storage[param.key] = value
+                        signal.tryEmit(param.key)
+                    }
+
+                    override suspend fun <T : Any> resetOverride(param: ConfigParam<T>) {
+                        storage.remove(param.key)
+                        signal.tryEmit(param.key)
+                    }
+
+                    override suspend fun clear() = storage.clear()
+
+                    // The same Flow object is returned each time observe() is called.
+                    // On retryWhen re-subscription the flow body re-executes, so shouldThrowOnCollection
+                    // controls whether the re-subscription succeeds.
+                    override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
+                        flow {
+                            if (shouldThrowOnCollection) {
+                                shouldThrowOnCollection = false
+                                throw RuntimeException("transient flow error")
+                            }
+                            // After recovery: emit current + forward signal emissions
+                            emit(get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT))
+                            signal.collect { key ->
+                                if (key == param.key) {
+                                    emit(get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT))
+                                }
+                            }
+                        }
+                }
+
+            val configValues =
+                ConfigValues(
+                    localProvider = faultyProvider,
+                    onProviderError = { collectedErrors += it },
+                )
+            val param = ConfigParam("flag", "default_val")
+
+            configValues.observe(param).test {
+                // Initial frame from the outer flow's getValue() — independent of localTrigger.
+                val first = awaitItem()
+                assertEquals("default_val", first.value)
+                assertEquals(ConfigValue.Source.DEFAULT, first.source)
+
+                // After retryWhen re-subscribes successfully, a local set() reaches the observer.
+                faultyProvider.set(param, "local_val")
+                val afterSet = awaitItem()
+                assertEquals("local_val", afterSet.value)
+                assertEquals(ConfigValue.Source.LOCAL, afterSet.source)
+
+                // The transient error was reported via onProviderError.
+                assertNotNull(collectedErrors.firstOrNull())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    /**
+     * G7: remote provider get() throws after fetch() → observe flow stays alive and the error
+     * reaches onProviderError; the frame falls back to the next available source.
+     *
+     * Setup: remote initially returns a value (REMOTE frame). Then remote.get() starts throwing.
+     * After fetch() the re-resolve fails on remote; no local override → falls back to DEFAULT.
+     * The flow must emit the DEFAULT frame (not stay silent) and must not terminate.
+     */
+    @Test
+    fun observeStaysAlive_whenRemoteGetThrowsAfterFetch() =
+        runTest {
+            val collectedErrors = mutableListOf<Throwable>()
+            val remote =
+                object : RemoteConfigValueProvider {
+                    private var stored: Any? = "initial_remote"
+                    var shouldThrow = false
+
+                    @Suppress("UNCHECKED_CAST")
+                    override suspend fun <T : Any> get(param: ConfigParam<T>): ConfigValue<T>? {
+                        if (shouldThrow) throw RuntimeException("remote exploded")
+                        return stored?.let { ConfigValue(it as T, ConfigValue.Source.REMOTE) }
+                    }
+
+                    override suspend fun fetch(activate: Boolean) = Unit
+                }
+
+            val configValues =
+                ConfigValues(
+                    localProvider = InMemoryConfigValueProvider(),
+                    remoteProvider = remote,
+                    onProviderError = { collectedErrors += it },
+                )
+            val param = ConfigParam("flag", "default_val")
+
+            configValues.observe(param).test {
+                // Initial: remote has a value → REMOTE frame
+                val first = awaitItem()
+                assertEquals("initial_remote", first.value)
+                assertEquals(ConfigValue.Source.REMOTE, first.source)
+
+                // Make remote throw on next get() and trigger a fetch
+                remote.shouldThrow = true
+                configValues.fetch()
+
+                // Re-resolve: remote throws (reported as error), no local → DEFAULT
+                val afterFetch = awaitItem()
+                assertEquals("default_val", afterFetch.value)
+                assertEquals(ConfigValue.Source.DEFAULT, afterFetch.source)
+
+                // Error must have been reported
+                assertNotNull(collectedErrors.firstOrNull())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    /**
+     * G8: provider observe() get() throws mid-stream (after first success) → ConfigValues.observe
+     * keeps delivering subsequent local changes after the provider recovers.
+     * Validates retryWhen on localTrigger + provider-level DEFAULT fallback.
+     */
+    @Test
+    fun observeKeepsDelivering_afterProviderGetThrowsMidStream_andRecovers() =
+        runTest {
+            val collectedErrors = mutableListOf<Throwable>()
+            val local = FailingGetLocalProvider()
+            val configValues =
+                ConfigValues(
+                    localProvider = local,
+                    onProviderError = { collectedErrors += it },
+                )
+            val param = ConfigParam("flag", "default_val")
+
+            // Pre-set a value so the initial frame is LOCAL
+            local.set(param, "value1")
+
+            configValues.observe(param).test {
+                // Initial LOCAL frame
+                val initial = awaitItem()
+                assertEquals("value1", initial.value)
+                assertEquals(ConfigValue.Source.LOCAL, initial.source)
+
+                // Trigger a change signal while get() will throw → provider emits DEFAULT fallback
+                local.setGetShouldThrow = true
+                local.set(param, "value2")
+
+                // Frame from the failing round: provider falls back to DEFAULT inside observe(),
+                // but ConfigValues.observe re-resolves via getValue() which also catches the error.
+                // The emitted frame value depends on whether the error happens inside the provider
+                // observe() map (DEFAULT from provider) or inside getValue(). Either way the flow
+                // must not terminate.
+                val afterError = awaitItem()
+                assertNotNull(afterError) // flow still alive
+
+                // Provider recovers — next set must produce a valid LOCAL frame
+                local.set(param, "value3")
+                val afterRecovery = awaitItem()
+                assertEquals("value3", afterRecovery.value)
+                assertEquals(ConfigValue.Source.LOCAL, afterRecovery.source)
+
                 cancelAndIgnoreRemainingEvents()
             }
         }

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ConfigValuesObserveContractTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ConfigValuesObserveContractTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -77,11 +78,15 @@ class ConfigValuesObserveContractTest {
          * Returns a Flow that ALWAYS emits on every key change — not filtered by [param].
          * This simulates DataStore's behaviour where a write to any preference triggers an
          * emission of the full preferences snapshot.
+         *
+         * onStart emits the current snapshot immediately upon subscription, mirroring real DataStore
+         * which always delivers the current value first. The re-resolve triggered by changeSignal
+         * for an unchanged key is suppressed by distinctUntilChanged inside ConfigValues.observe.
          */
         override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
-            changeSignal.map {
-                get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
-            }
+            changeSignal
+                .map { get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT) }
+                .onStart { emit(get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)) }
     }
 
     // --- test cases ---

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProviderTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProviderTest.kt
@@ -196,4 +196,49 @@ class InMemoryConfigValueProviderTest {
                 cancelAndIgnoreRemainingEvents()
             }
         }
+
+    // G2: clear() does not emit a change signal — pin the documented invariant.
+    @Test
+    fun clear_doesNotEmitChangeSignal() =
+        runTest {
+            val provider = InMemoryConfigValueProvider()
+            val param = ConfigParam("key", "default")
+            provider.set(param, "value")
+
+            provider.observe(param).test {
+                // consume initial emission
+                awaitItem()
+
+                provider.clear()
+
+                // clear() must not emit — no new events should follow
+                expectNoEvents()
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // G3: resetOverride after set → next frame is DEFAULT-sourced.
+    @Test
+    fun resetOverride_afterSet_emitsDefaultSourcedFrame() =
+        runTest {
+            val provider = InMemoryConfigValueProvider()
+            val param = ConfigParam("key", "my_default")
+            provider.set(param, "value")
+
+            provider.observe(param).test {
+                // Initial LOCAL frame
+                val initial = awaitItem()
+                assertEquals("value", initial.value)
+                assertEquals(ConfigValue.Source.LOCAL, initial.source)
+
+                // resetOverride → should emit DEFAULT-sourced frame
+                provider.resetOverride(param)
+                val afterReset = awaitItem()
+                assertEquals("my_default", afterReset.value)
+                assertEquals(ConfigValue.Source.DEFAULT, afterReset.source)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 }

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProviderTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProviderTest.kt
@@ -152,18 +152,22 @@ class InMemoryConfigValueProviderTest {
         }
 
     @Test
-    fun testObserveNonExistentParam() =
+    fun observeEmitsDefaultImmediately_whenKeyNeverWritten() =
         runTest {
             val provider = InMemoryConfigValueProvider()
-            val param = ConfigParam("non_existent", "default")
+            val param = ConfigParam("non_existent", "my_default")
 
             provider.observe(param).test {
-                // Should not emit anything initially since param doesn't exist
-                provider.set(param, "new_value")
+                // Contract: always emits immediately — DEFAULT when key is absent
+                val initial = awaitItem()
+                assertEquals("my_default", initial.value)
+                assertEquals(ConfigValue.Source.DEFAULT, initial.source)
 
-                val emission = awaitItem()
-                assertEquals("new_value", emission.value)
-                assertEquals(ConfigValue.Source.LOCAL, emission.source)
+                // Subsequent set emits LOCAL
+                provider.set(param, "new_value")
+                val afterSet = awaitItem()
+                assertEquals("new_value", afterSet.value)
+                assertEquals(ConfigValue.Source.LOCAL, afterSet.source)
 
                 cancelAndIgnoreRemainingEvents()
             }

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ProviderErrorObserveTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/ProviderErrorObserveTest.kt
@@ -53,25 +53,19 @@ class ProviderErrorObserveTest {
                     onProviderError = { errors.add(it) },
                 )
 
-            val collected = mutableListOf<String>()
-
-            // Collection must complete without throwing; the Flow stays alive after the
-            // local provider's Flow terminates with an exception.
+            // With the trigger-model, local provider emissions are used only as change
+            // signals — their payloads are discarded. getValue() is called for each signal,
+            // and since the local provider's get() returns null (no value stored), the
+            // resolved value is DEFAULT. Because the second DEFAULT equals the first,
+            // distinctUntilChanged suppresses it and no second frame is emitted.
             configValues.observe(testParam).test {
-                // Initial emission from getValue(param) — local provider's get() returns null
-                // so this resolves to the default value.
+                // Initial emission — local.get() returns null, falls through to DEFAULT.
                 val initial = awaitItem()
                 assertEquals("DEFAULT", initial.value)
                 assertEquals(ConfigValue.Source.DEFAULT, initial.source)
-                collected.add(initial.value)
 
-                // Emission from the local provider's observe() before it throws.
-                // distinctUntilChanged passes it because "local_value" ≠ "DEFAULT".
-                val fromLocal = awaitItem()
-                assertEquals("local_value", fromLocal.value)
-                assertEquals(ConfigValue.Source.LOCAL, fromLocal.source)
-                collected.add(fromLocal.value)
-
+                // No second frame: the signal from the local provider re-resolves to DEFAULT
+                // which is deduplicated. The exception is routed to onProviderError.
                 cancelAndIgnoreRemainingEvents()
             }
 
@@ -82,9 +76,5 @@ class ProviderErrorObserveTest {
                 "Expected IllegalStateException but was ${errors[0]::class}",
             )
             assertEquals("simulated provider error", errors[0].message)
-
-            // Both values were collected — flow did not crash before the second emission.
-            assertTrue("DEFAULT" in collected)
-            assertTrue("local_value" in collected)
         }
 }

--- a/providers/javaprefs/src/main/kotlin/dev/androidbroadcast/featured/javaprefs/JavaPreferencesConfigValueProvider.kt
+++ b/providers/javaprefs/src/main/kotlin/dev/androidbroadcast/featured/javaprefs/JavaPreferencesConfigValueProvider.kt
@@ -6,6 +6,7 @@ import dev.androidbroadcast.featured.LocalConfigValueProvider
 import dev.androidbroadcast.featured.TypeConverter
 import dev.androidbroadcast.featured.TypeConverters
 import dev.androidbroadcast.featured.put
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -162,7 +163,17 @@ public class JavaPreferencesConfigValueProvider(
             emitAll(
                 changedKeysFlow
                     .filter { it == param.key }
-                    .map { get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT) },
+                    .map {
+                        // Keep the observe stream alive on storage/converter errors; the error is
+                        // reported by the consumer's re-resolve via ConfigValues.getValue.
+                        try {
+                            get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
+                        } catch (ce: CancellationException) {
+                            throw ce
+                        } catch (_: Throwable) {
+                            ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
+                        }
+                    },
             )
         }.distinctUntilChanged()
 }

--- a/providers/javaprefs/src/main/kotlin/dev/androidbroadcast/featured/javaprefs/JavaPreferencesConfigValueProvider.kt
+++ b/providers/javaprefs/src/main/kotlin/dev/androidbroadcast/featured/javaprefs/JavaPreferencesConfigValueProvider.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -152,16 +151,20 @@ public class JavaPreferencesConfigValueProvider(
             node.flush()
         }
 
+    /**
+     * Conforms to [LocalConfigValueProvider.observe] contract: always emits immediately on
+     * collection — [ConfigValue.Source.LOCAL] when a value is stored,
+     * [ConfigValue.Source.DEFAULT] wrapping [ConfigParam.defaultValue] otherwise.
+     */
     override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
-        flow<ConfigValue<T>?> {
-            emit(get(param))
+        flow {
+            emit(get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT))
             emitAll(
                 changedKeysFlow
                     .filter { it == param.key }
-                    .map { get(param) },
+                    .map { get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT) },
             )
-        }.filterNotNull()
-            .distinctUntilChanged()
+        }.distinctUntilChanged()
 }
 
 /**

--- a/providers/javaprefs/src/test/kotlin/dev/androidbroadcast/featured/javaprefs/JavaPreferencesConfigValueProviderTest.kt
+++ b/providers/javaprefs/src/test/kotlin/dev/androidbroadcast/featured/javaprefs/JavaPreferencesConfigValueProviderTest.kt
@@ -188,16 +188,17 @@ class JavaPreferencesConfigValueProviderTest {
         }
 
     @Test
-    fun `observe emits null-skipped on resetOverride`() =
+    fun `observe emits DEFAULT on resetOverride when no value remains`() =
         runTest {
             provider.set(stringParam, "present")
 
-            // After resetOverride, observe should not emit (null is filtered)
             provider.observe(stringParam).test {
                 assertEquals("present", awaitItem().value)
 
                 provider.resetOverride(stringParam)
-                expectNoEvents()
+                val afterReset = awaitItem()
+                assertEquals("default", afterReset.value)
+                assertEquals(ConfigValue.Source.DEFAULT, afterReset.source)
 
                 cancelAndIgnoreRemainingEvents()
             }
@@ -265,10 +266,12 @@ class JavaPreferencesConfigValueProviderTest {
         }
 
     @Test
-    fun `observe emits nothing when value never set`() =
+    fun `observe emits DEFAULT immediately when key has never been written`() =
         runTest {
             provider.observe(stringParam).test {
-                expectNoEvents()
+                val emission = awaitItem()
+                assertEquals("default", emission.value)
+                assertEquals(ConfigValue.Source.DEFAULT, emission.source)
                 cancelAndIgnoreRemainingEvents()
             }
         }

--- a/providers/nsuserdefaults/src/iosMain/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProvider.kt
+++ b/providers/nsuserdefaults/src/iosMain/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProvider.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.map
 import platform.Foundation.NSUserDefaults
 
 /**
@@ -127,20 +127,22 @@ public class NSUserDefaultsConfigValueProvider(
     /**
      * Returns a [Flow] that emits a [ConfigValue] for [param] on every change to its key.
      *
-     * The flow emits the current persisted value immediately (skipping `null` if unset) and
-     * then emits again whenever [set] or [resetOverride] is called for the same key.
-     * Consecutive identical values are deduplicated via `distinctUntilChanged`.
+     * Conforms to [LocalConfigValueProvider.observe] contract: the flow always emits immediately
+     * upon collection — [ConfigValue.Source.LOCAL] when a value is persisted,
+     * [ConfigValue.Source.DEFAULT] wrapping [ConfigParam.defaultValue] otherwise. It then emits
+     * again whenever [set] or [resetOverride] is called for the same key. Consecutive identical
+     * values are deduplicated via `distinctUntilChanged`.
      *
      * @param param The configuration parameter to observe.
      * @return A cold [Flow] that completes when the collector's scope is cancelled.
      */
     override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
         flow {
-            get(param)?.let { emit(it) }
+            emit(get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT))
             emitAll(
                 changedKeyFlow
                     .filter { key -> key == param.key }
-                    .mapNotNull { get(param) },
+                    .map { get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT) },
             )
         }.distinctUntilChanged()
 

--- a/providers/nsuserdefaults/src/iosMain/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProvider.kt
+++ b/providers/nsuserdefaults/src/iosMain/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProvider.kt
@@ -3,6 +3,7 @@ package dev.androidbroadcast.featured.nsuserdefaults
 import dev.androidbroadcast.featured.ConfigParam
 import dev.androidbroadcast.featured.ConfigValue
 import dev.androidbroadcast.featured.LocalConfigValueProvider
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -142,7 +143,17 @@ public class NSUserDefaultsConfigValueProvider(
             emitAll(
                 changedKeyFlow
                     .filter { key -> key == param.key }
-                    .map { get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT) },
+                    .map {
+                        // Keep the observe stream alive on storage/converter errors; the error is
+                        // reported by the consumer's re-resolve via ConfigValues.getValue.
+                        try {
+                            get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
+                        } catch (ce: CancellationException) {
+                            throw ce
+                        } catch (_: Throwable) {
+                            ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
+                        }
+                    },
             )
         }.distinctUntilChanged()
 

--- a/providers/nsuserdefaults/src/iosTest/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProviderTest.kt
+++ b/providers/nsuserdefaults/src/iosTest/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProviderTest.kt
@@ -154,4 +154,26 @@ class NSUserDefaultsConfigValueProviderTest {
                 cancelAndIgnoreRemainingEvents()
             }
         }
+
+    // G5: resetOverride after set → observe emits DEFAULT-sourced frame.
+    @Test
+    fun `observe emits DEFAULT after resetOverride when value cleared`() =
+        runTest {
+            val param = ConfigParam("reset_obs_key", false)
+            provider.set(param, true)
+
+            provider.observe(param).test {
+                // Initial LOCAL frame
+                val initial = awaitItem()
+                assertEquals(true, initial.value)
+                assertEquals(ConfigValue.Source.LOCAL, initial.source)
+
+                provider.resetOverride(param)
+                val afterReset = awaitItem()
+                assertEquals(false, afterReset.value)
+                assertEquals(ConfigValue.Source.DEFAULT, afterReset.source)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 }

--- a/providers/nsuserdefaults/src/iosTest/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProviderTest.kt
+++ b/providers/nsuserdefaults/src/iosTest/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProviderTest.kt
@@ -141,4 +141,17 @@ class NSUserDefaultsConfigValueProviderTest {
                 cancelAndIgnoreRemainingEvents()
             }
         }
+
+    @Test
+    fun `observe emits DEFAULT immediately when key has never been written`() =
+        runTest {
+            val param = ConfigParam("never_written_bool", false)
+
+            provider.observe(param).test {
+                val emission = awaitItem()
+                assertEquals(false, emission.value)
+                assertEquals(ConfigValue.Source.DEFAULT, emission.source)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 }

--- a/providers/sharedpreferences/src/main/kotlin/dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfig.kt
+++ b/providers/sharedpreferences/src/main/kotlin/dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfig.kt
@@ -6,6 +6,7 @@ import dev.androidbroadcast.featured.ConfigParam
 import dev.androidbroadcast.featured.ConfigValue
 import dev.androidbroadcast.featured.LocalConfigValueProvider
 import dev.androidbroadcast.featured.TypeConverter
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -173,7 +174,17 @@ public class SharedPreferencesProviderConfig(
             emitAll(
                 changedKeysFlow
                     .filter { it == param.key }
-                    .map { get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT) },
+                    .map {
+                        // Keep the observe stream alive on storage/converter errors; the error is
+                        // reported by the consumer's re-resolve via ConfigValues.getValue.
+                        try {
+                            get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
+                        } catch (ce: CancellationException) {
+                            throw ce
+                        } catch (_: Throwable) {
+                            ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
+                        }
+                    },
             )
         }.distinctUntilChanged()
 }

--- a/providers/sharedpreferences/src/main/kotlin/dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfig.kt
+++ b/providers/sharedpreferences/src/main/kotlin/dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfig.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -159,24 +158,24 @@ public class SharedPreferencesProviderConfig(
     /**
      * Returns a [Flow] that emits a [ConfigValue] for [param] on every change to its key.
      *
-     * The flow emits the current persisted value immediately (skipping `null` if unset) and
-     * then emits again whenever [set], [resetOverride], or [remove] is called for the same
-     * key. Consecutive identical values are deduplicated via `distinctUntilChanged`.
+     * Conforms to [LocalConfigValueProvider.observe] contract: the flow always emits immediately
+     * upon collection — [ConfigValue.Source.LOCAL] when a value is persisted,
+     * [ConfigValue.Source.DEFAULT] wrapping [ConfigParam.defaultValue] otherwise. It then emits
+     * again whenever [set], [resetOverride], or [remove] is called for the same key.
+     * Consecutive identical values are deduplicated via `distinctUntilChanged`.
      *
      * @param param The configuration parameter to observe.
      * @return A cold [Flow] that completes when the collector's scope is cancelled.
      */
-    override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> {
-        return flow<ConfigValue<T>?> {
-            emit(get(param)) // Emit the current value first
-            emitAll( // Then emit changes
+    override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
+        flow {
+            emit(get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT))
+            emitAll(
                 changedKeysFlow
                     .filter { it == param.key }
-                    .map { get(param) },
+                    .map { get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT) },
             )
-        }.filterNotNull()
-            .distinctUntilChanged() // Avoid emitting the same value multiple times
-    }
+        }.distinctUntilChanged()
 }
 
 /**

--- a/providers/sharedpreferences/src/test/kotlin/dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfigTest.kt
+++ b/providers/sharedpreferences/src/test/kotlin/dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfigTest.kt
@@ -397,6 +397,28 @@ class SharedPreferencesProviderConfigTest {
             }
         }
 
+    // G4: resetOverride after set → observe emits DEFAULT-sourced frame.
+    @Test
+    fun `observe emits DEFAULT after resetOverride when no value remains`() =
+        runTest {
+            val param = ConfigParam("reset_key", "my_default")
+            provider.set(param, "stored")
+
+            provider.observe(param).test {
+                // Consume initial LOCAL frame
+                val initial = awaitItem()
+                assertEquals("stored", initial.value)
+                assertEquals(ConfigValue.Source.LOCAL, initial.source)
+
+                provider.resetOverride(param)
+                val afterReset = awaitItem()
+                assertEquals("my_default", afterReset.value)
+                assertEquals(ConfigValue.Source.DEFAULT, afterReset.source)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     @Test
     fun `additionalContext is included in the merged coroutine context`() {
         val coroutineName = CoroutineName("test-context-inclusion")

--- a/providers/sharedpreferences/src/test/kotlin/dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfigTest.kt
+++ b/providers/sharedpreferences/src/test/kotlin/dev/androidbroadcast/featured/sharedpreferences/SharedPreferencesProviderConfigTest.kt
@@ -385,6 +385,19 @@ class SharedPreferencesProviderConfigTest {
         }
 
     @Test
+    fun `observe emits DEFAULT immediately when key has never been written`() =
+        runTest {
+            val param = ConfigParam("never_written_key", "my_default")
+
+            provider.observe(param).test {
+                val emission = awaitItem()
+                assertEquals("my_default", emission.value)
+                assertEquals(ConfigValue.Source.DEFAULT, emission.source)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun `additionalContext is included in the merged coroutine context`() {
         val coroutineName = CoroutineName("test-context-inclusion")
         val context: Application = ApplicationProvider.getApplicationContext()


### PR DESCRIPTION
Closes #252

## What
- **Normative `LocalConfigValueProvider.observe()` contract**: the flow ALWAYS emits immediately on collection — the stored value, or `ConfigValue(defaultValue, Source.DEFAULT)` when the key was never written — then on every change. `DataStoreConfigValueProvider` is the reference implementation; sharedpreferences, javaprefs, nsuserdefaults and `InMemoryConfigValueProvider` are brought to the contract (no more silent `filterNotNull` flows). Contract KDoc also pins: the flow never completes normally, storage errors must not kill it (DEFAULT-sourced fallback), `clear()` behavior note, payload-type rationale.
- **`ConfigValues.observe()` rewritten to a trigger model**: local emissions are change *signals* only — every downstream frame is a full `getValue()` re-resolve through the priority chain, deduplicated by full `ConfigValue` equality. This eliminates the DEFAULT-clobbers-REMOTE flicker and the merge-ordering race by construction.
- **Streams survive provider failures**: provider observe mappings guard `get()` (CE rethrown, otherwise DEFAULT fallback); core local trigger uses `retryWhen` with bounded backoff instead of a terminal `catch` — a misbehaving provider can no longer permanently silence local change signals.

## Breaking
Behavioral change for users of sharedpreferences / javaprefs / nsuserdefaults / InMemory providers: `observe()` now emits immediately for absent keys (previously silent). Third-party `LocalConfigValueProvider` implementations must adopt the always-emit contract.

## Verification
- New `ConfigValuesObserveContractTest` — frame-sequence tests asserting count and order (no intermediate DEFAULT frames, mid-stream fetch race, whole-store provider dedup, warmUp/fetch interplay, error recovery paths); per-provider contract tests incl. DataStore as reference and `resetOverride → DEFAULT` emissions; `:core:koverVerify` ≥90%; nsuserdefaults verified on iOS simulator locally (CI does not run sim tests).
- Architecture review confirmed the integration seam with the per-item debug-ui subscriptions (#263) and the warm-set refresh (#261).
- finalize PASS, acceptance VERIFIED. Local assemble gate per #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)