### PR TITLE
Add Reset All Overrides with undo to debug screen

### DIFF
--- a/featured-debug-ui/src/commonMain/kotlin/dev/androidbroadcast/featured/debugui/FeatureFlagsDebugScreen.kt
+++ b/featured-debug-ui/src/commonMain/kotlin/dev/androidbroadcast/featured/debugui/FeatureFlagsDebugScreen.kt
@@ -214,7 +214,8 @@ public fun FeatureFlagsDebugScreen(
     if (showResetAllDialog) {
         AlertDialog(
             onDismissRequest = { showResetAllDialog = false },
-            title = { Text("Reset ${resetPlan.size} overrides?") },
+            title = { Text("Reset ${overrideLabel(resetPlan.size)}?") },
+            text = { Text("Values return to remote or default. You can undo from the snackbar.") },
             confirmButton = {
                 TextButton(
                     onClick = {
@@ -223,9 +224,14 @@ public fun FeatureFlagsDebugScreen(
                         // starts) so undo has consistent values even if subscriptions fire
                         // between resets.
                         val plan = resetPlan
+                        // Navigation away cancels this job; completed resets stay applied
+                        // and undo is not offered after disposal — acceptable for a debug surface.
                         scope.launch {
                             // Parallel reset — isolate per-item failures so one bad provider
                             // cannot prevent other params from being reset.
+                            // Single-threaded UI dispatcher: failedKeys is written only from
+                            // this coroutine's continuation; plain mutable list is race-free.
+                            val failedKeys = mutableListOf<String>()
                             coroutineScope {
                                 plan
                                     .map { entry ->
@@ -234,6 +240,7 @@ public fun FeatureFlagsDebugScreen(
                                                 configValues.resetOverride(entry.param)
                                             }.onFailure { e ->
                                                 if (e is CancellationException) throw e
+                                                failedKeys += entry.param.key
                                                 println(
                                                     "Featured debug-ui: failed to reset override for '${entry.param.key}': $e",
                                                 )
@@ -242,32 +249,51 @@ public fun FeatureFlagsDebugScreen(
                                     }.forEach { it.await() }
                             }
 
+                            val resetCount = plan.size - failedKeys.size
+                            val resetMessage =
+                                if (failedKeys.isEmpty()) {
+                                    "Reset ${overrideLabel(plan.size)}"
+                                } else {
+                                    "Reset $resetCount of ${plan.size} overrides"
+                                }
                             val result =
                                 snackbarHostState.showSnackbar(
-                                    message = "Reset ${plan.size} overrides",
+                                    message = resetMessage,
                                     actionLabel = "Undo",
                                     duration = SnackbarDuration.Long,
                                 )
                             if (result == SnackbarResult.ActionPerformed) {
                                 // Undo: restore all snapshotted values in parallel.
-                                coroutineScope {
-                                    plan
-                                        .map { entry ->
-                                            async {
-                                                runCatching {
-                                                    @Suppress("UNCHECKED_CAST")
-                                                    configValues.override(
-                                                        entry.param as ConfigParam<Any>,
-                                                        entry.previousValue,
-                                                    )
-                                                }.onFailure { e ->
-                                                    if (e is CancellationException) throw e
-                                                    println(
-                                                        "Featured debug-ui: failed to restore override for '${entry.param.key}': $e",
-                                                    )
-                                                }
+                                val undoFailCount =
+                                    mutableListOf<String>()
+                                        .also { undoFailed ->
+                                            coroutineScope {
+                                                plan
+                                                    .map { entry ->
+                                                        async {
+                                                            runCatching {
+                                                                @Suppress("UNCHECKED_CAST")
+                                                                configValues.override(
+                                                                    entry.param as ConfigParam<Any>,
+                                                                    entry.previousValue,
+                                                                )
+                                                            }.onFailure { e ->
+                                                                if (e is CancellationException) throw e
+                                                                undoFailed += entry.param.key
+                                                                println(
+                                                                    "Featured debug-ui: failed to restore override for '${entry.param.key}': $e",
+                                                                )
+                                                            }
+                                                        }
+                                                    }.forEach { it.await() }
                                             }
-                                        }.forEach { it.await() }
+                                        }.size
+                                if (undoFailCount > 0) {
+                                    val restoredCount = plan.size - undoFailCount
+                                    snackbarHostState.showSnackbar(
+                                        message = "Restored $restoredCount of ${plan.size} overrides",
+                                        duration = SnackbarDuration.Short,
+                                    )
                                 }
                             }
                         }
@@ -507,6 +533,9 @@ public fun FeatureFlagsDebugScreen(
         }
     }
 }
+
+/** Returns "1 override" or "N overrides" for use in dialog titles and snackbar messages. */
+private fun overrideLabel(count: Int): String = if (count == 1) "1 override" else "$count overrides"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/featured-debug-ui/src/commonMain/kotlin/dev/androidbroadcast/featured/debugui/FeatureFlagsDebugScreen.kt
+++ b/featured-debug-ui/src/commonMain/kotlin/dev/androidbroadcast/featured/debugui/FeatureFlagsDebugScreen.kt
@@ -215,7 +215,6 @@ public fun FeatureFlagsDebugScreen(
         AlertDialog(
             onDismissRequest = { showResetAllDialog = false },
             title = { Text("Reset ${resetPlan.size} overrides?") },
-            text = { Text("This cannot be undone.") },
             confirmButton = {
                 TextButton(
                     onClick = {

--- a/featured-debug-ui/src/commonMain/kotlin/dev/androidbroadcast/featured/debugui/FeatureFlagsDebugScreen.kt
+++ b/featured-debug-ui/src/commonMain/kotlin/dev/androidbroadcast/featured/debugui/FeatureFlagsDebugScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -25,6 +26,10 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -70,6 +75,8 @@ import kotlin.coroutines.cancellation.CancellationException
  * "Reset to default" button that clears the override.
  *
  * Supports search by flag key/category and filtering to locally-overridden flags only.
+ * A "Reset all overrides" action in the top bar resets every overridden flag at once and
+ * offers an undo snackbar.
  *
  * Intended for debug/internal builds only.
  *
@@ -95,6 +102,7 @@ public fun FeatureFlagsDebugScreen(
     modifier: Modifier = Modifier,
 ) {
     val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
 
     // Per-item state map: each param key → its current DebugFlagItem.
     // Built once at startup (parallel) then updated individually on each param change.
@@ -110,6 +118,9 @@ public fun FeatureFlagsDebugScreen(
     var searchQuery by rememberSaveable { mutableStateOf("") }
     var isSearchActive by rememberSaveable { mutableStateOf(false) }
     var overriddenOnly by rememberSaveable { mutableStateOf(false) }
+
+    // Whether the "Reset all" confirmation dialog is open.
+    var showResetAllDialog by remember { mutableStateOf(false) }
 
     // Auto-focus on first expansion only — not on state restoration after a config change.
     // rememberSaveable ensures hasFocusedOnce survives activity recreation alongside
@@ -193,8 +204,90 @@ public fun FeatureFlagsDebugScreen(
     // True when the registry is non-empty but active filters produce no matches.
     val isEmptyDueToFilter = allItems.isNotEmpty() && filteredItems.isEmpty()
 
+    // Compute the reset plan from the full (unfiltered) item list so the "Reset all" count
+    // and enabled state always reflect the actual number of overridden flags, regardless of
+    // which filter is active.
+    val resetPlan = buildResetPlan(allItems)
+    val hasOverrides = resetPlan.isNotEmpty()
+
+    // "Reset all" confirmation dialog — shown before committing any changes.
+    if (showResetAllDialog) {
+        AlertDialog(
+            onDismissRequest = { showResetAllDialog = false },
+            title = { Text("Reset ${resetPlan.size} overrides?") },
+            text = { Text("This cannot be undone.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showResetAllDialog = false
+                        // Snapshot then reset: capture the plan NOW (before any async work
+                        // starts) so undo has consistent values even if subscriptions fire
+                        // between resets.
+                        val plan = resetPlan
+                        scope.launch {
+                            // Parallel reset — isolate per-item failures so one bad provider
+                            // cannot prevent other params from being reset.
+                            coroutineScope {
+                                plan
+                                    .map { entry ->
+                                        async {
+                                            runCatching {
+                                                configValues.resetOverride(entry.param)
+                                            }.onFailure { e ->
+                                                if (e is CancellationException) throw e
+                                                println(
+                                                    "Featured debug-ui: failed to reset override for '${entry.param.key}': $e",
+                                                )
+                                            }
+                                        }
+                                    }.forEach { it.await() }
+                            }
+
+                            val result =
+                                snackbarHostState.showSnackbar(
+                                    message = "Reset ${plan.size} overrides",
+                                    actionLabel = "Undo",
+                                    duration = SnackbarDuration.Long,
+                                )
+                            if (result == SnackbarResult.ActionPerformed) {
+                                // Undo: restore all snapshotted values in parallel.
+                                coroutineScope {
+                                    plan
+                                        .map { entry ->
+                                            async {
+                                                runCatching {
+                                                    @Suppress("UNCHECKED_CAST")
+                                                    configValues.override(
+                                                        entry.param as ConfigParam<Any>,
+                                                        entry.previousValue,
+                                                    )
+                                                }.onFailure { e ->
+                                                    if (e is CancellationException) throw e
+                                                    println(
+                                                        "Featured debug-ui: failed to restore override for '${entry.param.key}': $e",
+                                                    )
+                                                }
+                                            }
+                                        }.forEach { it.await() }
+                                }
+                            }
+                        }
+                    },
+                ) {
+                    Text("Reset")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showResetAllDialog = false }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+
     Scaffold(
         modifier = modifier,
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         topBar = {
             if (isSearchActive) {
                 SearchTopAppBar(
@@ -210,7 +303,16 @@ public fun FeatureFlagsDebugScreen(
                 TopAppBar(
                     title = { Text("Feature Flags") },
                     actions = {
-                        // Space reserved for a future «Reset all overrides» action.
+                        TextButton(
+                            onClick = { showResetAllDialog = true },
+                            enabled = hasOverrides,
+                            modifier =
+                                Modifier.semantics {
+                                    contentDescription = "Reset all overrides"
+                                },
+                        ) {
+                            Text("Reset all")
+                        }
                         TextButton(
                             onClick = {
                                 isSearchActive = true
@@ -278,6 +380,9 @@ public fun FeatureFlagsDebugScreen(
 
                 isEmptyDueToFilter -> {
                     // Registry has flags but none pass the active filters.
+                    // The snackbar must be visible above this state — SnackbarHost is in
+                    // the Scaffold so it is always rendered in the correct z-layer above
+                    // the content regardless of which branch is shown here.
                     Column(
                         modifier = Modifier.fillMaxSize(),
                         verticalArrangement = Arrangement.Center,

--- a/featured-debug-ui/src/commonMain/kotlin/dev/androidbroadcast/featured/debugui/FlagFilter.kt
+++ b/featured-debug-ui/src/commonMain/kotlin/dev/androidbroadcast/featured/debugui/FlagFilter.kt
@@ -1,5 +1,6 @@
 package dev.androidbroadcast.featured.debugui
 
+import dev.androidbroadcast.featured.ConfigParam
 import dev.androidbroadcast.featured.ConfigValue
 
 /**
@@ -24,3 +25,28 @@ internal fun filterFlags(
         matchesQuery && matchesOverride
     }
 }
+
+/**
+ * A snapshot of a single overridden flag: the param to reset and the value to restore on undo.
+ */
+internal data class ResetEntry<T : Any>(
+    val param: ConfigParam<T>,
+    val previousValue: T,
+)
+
+/**
+ * Builds a reset plan from [items]: returns one [ResetEntry] per item that has
+ * [DebugFlagItem.isOverridden] == true. The [ResetEntry.previousValue] captures the
+ * current override value at the moment this function is called, so undo can restore it.
+ *
+ * An empty list means no items are overridden — "Reset all" should be disabled.
+ */
+internal fun buildResetPlan(items: List<DebugFlagItem<*>>): List<ResetEntry<*>> =
+    items
+        .filter { it.isOverridden }
+        .mapNotNull { item ->
+            @Suppress("UNCHECKED_CAST")
+            val typedItem = item as? DebugFlagItem<Any> ?: return@mapNotNull null
+            val overrideValue = typedItem.overrideValue ?: return@mapNotNull null
+            ResetEntry(param = typedItem.param, previousValue = overrideValue)
+        }

--- a/featured-debug-ui/src/commonTest/kotlin/dev/androidbroadcast/featured/debugui/ResetPlanTest.kt
+++ b/featured-debug-ui/src/commonTest/kotlin/dev/androidbroadcast/featured/debugui/ResetPlanTest.kt
@@ -1,0 +1,151 @@
+package dev.androidbroadcast.featured.debugui
+
+import dev.androidbroadcast.featured.ConfigParam
+import dev.androidbroadcast.featured.ConfigValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ResetPlanTest {
+    private fun makeItem(
+        key: String,
+        defaultValue: Boolean,
+        overrideValue: Boolean?,
+        source: ConfigValue.Source = if (overrideValue != null) ConfigValue.Source.LOCAL else ConfigValue.Source.DEFAULT,
+    ) = DebugFlagItem(
+        param = ConfigParam(key = key, defaultValue = defaultValue),
+        currentValue = overrideValue ?: defaultValue,
+        overrideValue = overrideValue,
+        source = source,
+    )
+
+    private fun makeStringItem(
+        key: String,
+        defaultValue: String,
+        overrideValue: String?,
+        source: ConfigValue.Source = if (overrideValue != null) ConfigValue.Source.LOCAL else ConfigValue.Source.DEFAULT,
+    ) = DebugFlagItem(
+        param = ConfigParam(key = key, defaultValue = defaultValue),
+        currentValue = overrideValue ?: defaultValue,
+        overrideValue = overrideValue,
+        source = source,
+    )
+
+    private fun makeIntItem(
+        key: String,
+        defaultValue: Int,
+        overrideValue: Int?,
+        source: ConfigValue.Source = if (overrideValue != null) ConfigValue.Source.LOCAL else ConfigValue.Source.DEFAULT,
+    ) = DebugFlagItem(
+        param = ConfigParam(key = key, defaultValue = defaultValue),
+        currentValue = overrideValue ?: defaultValue,
+        overrideValue = overrideValue,
+        source = source,
+    )
+
+    // --- plan set == overridden set ---
+
+    @Test
+    fun buildResetPlan_onlyIncludesOverriddenItems() {
+        val overridden = makeItem("flag_on", defaultValue = false, overrideValue = true)
+        val notOverridden = makeItem("flag_off", defaultValue = true, overrideValue = null)
+        val plan = buildResetPlan(listOf(overridden, notOverridden))
+        assertEquals(1, plan.size)
+        assertEquals("flag_on", plan[0].param.key)
+    }
+
+    @Test
+    fun buildResetPlan_includesAllOverriddenItems() {
+        val items =
+            listOf(
+                makeItem("a", defaultValue = false, overrideValue = true),
+                makeIntItem("b", defaultValue = 0, overrideValue = 42),
+                makeStringItem("c", defaultValue = "x", overrideValue = null),
+                makeStringItem("d", defaultValue = "y", overrideValue = "z"),
+            )
+        val plan = buildResetPlan(items)
+        assertEquals(3, plan.size)
+        val keys = plan.map { it.param.key }.toSet()
+        assertEquals(setOf("a", "b", "d"), keys)
+    }
+
+    // --- values captured correctly ---
+
+    @Test
+    fun buildResetPlan_capturesCurrentOverrideValue() {
+        val item = makeStringItem("flag", defaultValue = "original", overrideValue = "override")
+        val plan = buildResetPlan(listOf(item))
+        assertEquals(1, plan.size)
+        // The previousValue must be the override value, not the default.
+        assertEquals("override", plan[0].previousValue)
+    }
+
+    @Test
+    fun buildResetPlan_capturesBooleanOverrideValue() {
+        val item = makeItem("bool_flag", defaultValue = false, overrideValue = true)
+        val plan = buildResetPlan(listOf(item))
+        assertEquals(true, plan[0].previousValue)
+    }
+
+    @Test
+    fun buildResetPlan_capturesIntOverrideValue() {
+        val item = makeIntItem("int_flag", defaultValue = 0, overrideValue = 99)
+        val plan = buildResetPlan(listOf(item))
+        assertEquals(99, plan[0].previousValue)
+    }
+
+    // --- empty plan → action disabled semantics ---
+
+    @Test
+    fun buildResetPlan_emptyListProducesEmptyPlan() {
+        val plan = buildResetPlan(emptyList())
+        assertTrue(plan.isEmpty())
+    }
+
+    @Test
+    fun buildResetPlan_noOverridesProducesEmptyPlan() {
+        val items =
+            listOf(
+                makeItem("a", defaultValue = true, overrideValue = null),
+                makeStringItem("b", defaultValue = "hello", overrideValue = null),
+                makeIntItem("c", defaultValue = 0, overrideValue = null),
+            )
+        val plan = buildResetPlan(items)
+        // Empty plan means "Reset all" should be disabled.
+        assertTrue(plan.isEmpty())
+    }
+
+    @Test
+    fun buildResetPlan_emptyPlanImpliesHasOverridesFalse() {
+        val items = listOf(makeItem("x", defaultValue = false, overrideValue = null))
+        val plan = buildResetPlan(items)
+        // hasOverrides = plan.isNotEmpty() — false means button disabled.
+        assertEquals(false, plan.isNotEmpty())
+    }
+
+    @Test
+    fun buildResetPlan_nonEmptyPlanImpliesHasOverridesTrue() {
+        val items = listOf(makeItem("x", defaultValue = false, overrideValue = true))
+        val plan = buildResetPlan(items)
+        assertEquals(true, plan.isNotEmpty())
+    }
+
+    // --- param reference is preserved ---
+
+    @Test
+    fun buildResetPlan_preservesParamReference() {
+        val param = ConfigParam(key = "param_key", defaultValue = "default")
+        val item =
+            DebugFlagItem(
+                param = param,
+                currentValue = "overridden",
+                overrideValue = "overridden",
+                source = ConfigValue.Source.LOCAL,
+            )
+        val plan = buildResetPlan(listOf(item))
+        assertEquals(1, plan.size)
+        // The param in the entry must be the same instance used to call resetOverride.
+        assertEquals(param.key, plan[0].param.key)
+        assertEquals(param.defaultValue, plan[0].param.defaultValue)
+    }
+}


### PR DESCRIPTION
Closes #254

## What
- «Reset all» action in the debug screen's top bar (disabled when nothing is overridden; hidden while search is expanded).
- Confirmation dialog with a live count («Reset N override(s)?» + consequence note), Cancel is a no-op.
- Strict snapshot-then-reset: override values are captured synchronously before parallel `resetOverride` calls (existing core API — no new API needed, see #255).
- Snackbar (Long) with **Undo** restoring only the previously-overridden params; partial failures are reported honestly («Reset K of N overrides», «Restored K of N overrides»).
- Pure `buildResetPlan` logic extracted and unit-tested (11 commonTest cases).

## Verification
- Manual QA on Pixel 10 AVD, e2e steps 14–19: **6/6 PASS** including snackbar reachability above the «Overridden only» empty state and full Undo round-trip.
- finalize PASS (review loop; partial-failure feedback added per silent-failure review), acceptance VERIFIED.
- Known project-wide notes: println diagnostics pattern → follow-up #268; local assemble gate per #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)