### PR TITLE
Notify observers on clear and scope NSUserDefaults deletion

### DIFF
--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProvider.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProvider.kt
@@ -34,7 +34,7 @@ public class InMemoryConfigValueProvider : LocalConfigValueProvider {
     // AtomicReference wrapping an immutable Map prevents lost updates when resetOverride is called
     // concurrently from multiple coroutines (e.g. parallel Reset All from the debug UI).
     private val storageRef = AtomicReference(emptyMap<String, Any>())
-    private val changedKeyFlow = MutableSharedFlow<String>(extraBufferCapacity = 1000)
+    private val changedKeyFlow = MutableSharedFlow<String>(extraBufferCapacity = Int.MAX_VALUE)
 
     /**
      * Returns the locally stored value for [param], or `null` if no override has been set.
@@ -62,7 +62,7 @@ public class InMemoryConfigValueProvider : LocalConfigValueProvider {
         value: T,
     ) {
         storageRef.update { it + (param.key to value) }
-        changedKeyFlow.emit(param.key)
+        changedKeyFlow.tryEmit(param.key)
     }
 
     /**
@@ -75,7 +75,7 @@ public class InMemoryConfigValueProvider : LocalConfigValueProvider {
      */
     public override suspend fun <T : Any> resetOverride(param: ConfigParam<T>) {
         storageRef.update { it - param.key }
-        changedKeyFlow.emit(param.key)
+        changedKeyFlow.tryEmit(param.key)
     }
 
     /**
@@ -85,16 +85,13 @@ public class InMemoryConfigValueProvider : LocalConfigValueProvider {
      * After this call, [get] returns `null` for every parameter that was previously overridden,
      * and active [observe] flows emit a [ConfigValue] with [ConfigValue.Source.DEFAULT].
      *
-     * The keys snapshot is taken atomically before clearing; each removed key is then emitted
-     * into the change-signal flow so that observers can react without calling [resetOverride]
-     * per parameter.
+     * The map is replaced atomically via a single [AtomicReference.exchange]; the keys of the
+     * returned previous map are the authoritative set of removed keys, eliminating the TOCTOU
+     * window that a separate load() + update() sequence would leave.
      */
     public override suspend fun clear() {
-        val removedKeys = storageRef.load().keys.toList()
-        storageRef.update { emptyMap() }
-        for (key in removedKeys) {
-            changedKeyFlow.emit(key)
-        }
+        val removedKeys = storageRef.exchange(emptyMap()).keys
+        removedKeys.forEach { key -> changedKeyFlow.tryEmit(key) }
     }
 
     /**
@@ -108,6 +105,10 @@ public class InMemoryConfigValueProvider : LocalConfigValueProvider {
      * [ConfigValue.Source.DEFAULT].
      *
      * The flow completes only when the collector's scope is cancelled.
+     *
+     * A [ClassCastException] from a type-mismatched [ConfigParam] (programming error) is caught
+     * in the reactive path and surfaces as [ConfigValue.Source.DEFAULT] rather than terminating
+     * the flow with an exception.
      *
      * @param param The configuration parameter to observe.
      * @return A cold [kotlinx.coroutines.flow.Flow] of [ConfigValue] snapshots.

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProvider.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProvider.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlin.concurrent.atomics.ExperimentalAtomicApi::class)
+
 package dev.androidbroadcast.featured
 
 import kotlinx.coroutines.CancellationException
@@ -7,16 +9,18 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.update
 
 /**
  * A [LocalConfigValueProvider] that stores configuration overrides in memory.
  *
- * Values are held in a plain [Map] and are lost when the process terminates. This makes
- * [InMemoryConfigValueProvider] ideal for tests, Compose previews, and ephemeral runtime
- * overrides that do not need to survive process death.
+ * Values are held in an [kotlin.concurrent.atomics.AtomicReference] of an immutable [Map] and are lost when the
+ * process terminates. This makes [InMemoryConfigValueProvider] ideal for tests, Compose previews,
+ * and ephemeral runtime overrides that do not need to survive process death.
  *
- * [set] and [resetOverride] emit a change signal that causes active [observe] flows to
- * re-evaluate and emit the updated value. [clear] does not emit signals — see its KDoc.
+ * [set], [resetOverride], and [clear] emit change signals that cause active [observe] flows to
+ * re-evaluate and emit the updated (or default) value.
  *
  * ```kotlin
  * val provider = InMemoryConfigValueProvider()
@@ -27,7 +31,9 @@ import kotlinx.coroutines.flow.map
  * ```
  */
 public class InMemoryConfigValueProvider : LocalConfigValueProvider {
-    private var storage: Map<String, Any> = emptyMap()
+    // AtomicReference wrapping an immutable Map prevents lost updates when resetOverride is called
+    // concurrently from multiple coroutines (e.g. parallel Reset All from the debug UI).
+    private val storageRef = AtomicReference(emptyMap<String, Any>())
     private val changedKeyFlow = MutableSharedFlow<String>(extraBufferCapacity = 1000)
 
     /**
@@ -38,7 +44,7 @@ public class InMemoryConfigValueProvider : LocalConfigValueProvider {
      */
     @Suppress("UNCHECKED_CAST")
     override suspend fun <T : Any> get(param: ConfigParam<T>): ConfigValue<T>? =
-        storage[param.key]?.let { value ->
+        storageRef.load()[param.key]?.let { value ->
             ConfigValue(
                 value as T,
                 source = ConfigValue.Source.LOCAL,
@@ -55,7 +61,7 @@ public class InMemoryConfigValueProvider : LocalConfigValueProvider {
         param: ConfigParam<T>,
         value: T,
     ) {
-        storage += param.key to value
+        storageRef.update { it + (param.key to value) }
         changedKeyFlow.emit(param.key)
     }
 
@@ -68,31 +74,40 @@ public class InMemoryConfigValueProvider : LocalConfigValueProvider {
      * @param param The configuration parameter whose override should be cleared.
      */
     public override suspend fun <T : Any> resetOverride(param: ConfigParam<T>) {
-        storage = storage - param.key
+        storageRef.update { it - param.key }
         changedKeyFlow.emit(param.key)
     }
 
     /**
-     * Removes all stored overrides, resetting the provider to an empty state.
+     * Removes all stored overrides and notifies active [observe] flows for every key that
+     * was previously set.
      *
-     * Unlike [resetOverride], this does **not** emit change signals. Callers that need
-     * reactive updates after a bulk clear should call [resetOverride] per param instead.
+     * After this call, [get] returns `null` for every parameter that was previously overridden,
+     * and active [observe] flows emit a [ConfigValue] with [ConfigValue.Source.DEFAULT].
+     *
+     * The keys snapshot is taken atomically before clearing; each removed key is then emitted
+     * into the change-signal flow so that observers can react without calling [resetOverride]
+     * per parameter.
      */
     public override suspend fun clear() {
-        storage = emptyMap()
+        val removedKeys = storageRef.load().keys.toList()
+        storageRef.update { emptyMap() }
+        for (key in removedKeys) {
+            changedKeyFlow.emit(key)
+        }
     }
 
     /**
      * Returns a [kotlinx.coroutines.flow.Flow] that emits the current value for [param]
-     * immediately and then emits again on every subsequent [set] or [resetOverride] call
-     * for the same key.
+     * immediately and then emits again on every subsequent [set], [resetOverride], or [clear]
+     * call that affects the same key.
      *
      * Conforms to [LocalConfigValueProvider.observe] contract: the initial emission is always
      * present — [ConfigValue.Source.LOCAL] when a value is stored, [ConfigValue.Source.DEFAULT]
-     * wrapping [ConfigParam.defaultValue] otherwise.
+     * wrapping [ConfigParam.defaultValue] otherwise. After [clear], affected observers emit
+     * [ConfigValue.Source.DEFAULT].
      *
-     * The flow completes only when the collector's scope is cancelled. It does **not** emit
-     * after [clear] because [clear] does not signal individual key changes.
+     * The flow completes only when the collector's scope is cancelled.
      *
      * @param param The configuration parameter to observe.
      * @return A cold [kotlinx.coroutines.flow.Flow] of [ConfigValue] snapshots.

--- a/core/src/commonMain/kotlin/dev/androidbroadcast/featured/LocalConfigValueProvider.kt
+++ b/core/src/commonMain/kotlin/dev/androidbroadcast/featured/LocalConfigValueProvider.kt
@@ -54,12 +54,11 @@ public interface LocalConfigValueProvider : ConfigValueProvider {
      * fallback instead. The error is surfaced separately through [ConfigValues.observe] when it
      * re-resolves via [ConfigValues.getValue] and calls [onProviderError][ConfigValues.onProviderError].
      *
-     * **After [clear]:** behavior is implementation-defined. [InMemoryConfigValueProvider] does
-     * not emit after [clear] because [clear] does not signal individual key changes. Persistent
-     * providers backed by system storage (SharedPreferences, NSUserDefaults, DataStore) may or
-     * may not emit depending on whether their storage layer fires a change notification.
-     * Callers that need reliable reactive updates after a bulk clear should call [resetOverride]
-     * per parameter instead.
+     * **After [clear]:** both reference implementations ([InMemoryConfigValueProvider] and
+     * [dev.androidbroadcast.featured.nsuserdefaults.NSUserDefaultsConfigValueProvider]) emit a
+     * [ConfigValue] with [ConfigValue.Source.DEFAULT] for every key that was removed. Custom
+     * implementations are strongly encouraged to follow the same contract so that callers do not
+     * need to call [resetOverride] per parameter after a bulk clear.
      *
      * **Payload:** the flow emits [ConfigValue]`<T>` rather than [Unit] so that consumers other
      * than [ConfigValues] — such as custom observers that bypass the priority chain — can use the

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProviderTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProviderTest.kt
@@ -1,6 +1,7 @@
 package dev.androidbroadcast.featured
 
 import app.cash.turbine.test
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -197,24 +198,86 @@ class InMemoryConfigValueProviderTest {
             }
         }
 
-    // G2: clear() does not emit a change signal — pin the documented invariant.
+    // G2: clear() emits DEFAULT for every key that was set — contract change from prior behavior.
     @Test
-    fun clear_doesNotEmitChangeSignal() =
+    fun clearEmitsDefaultForPreviouslySetKey() =
         runTest {
             val provider = InMemoryConfigValueProvider()
             val param = ConfigParam("key", "default")
             provider.set(param, "value")
 
             provider.observe(param).test {
-                // consume initial emission
+                // consume initial LOCAL emission
                 awaitItem()
 
                 provider.clear()
 
-                // clear() must not emit — no new events should follow
+                val afterClear = awaitItem()
+                assertEquals("default", afterClear.value)
+                assertEquals(ConfigValue.Source.DEFAULT, afterClear.source)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun clearEmitsDefaultForEachSetKey() =
+        runTest {
+            val provider = InMemoryConfigValueProvider()
+            val param1 = ConfigParam("k1", "d1")
+            val param2 = ConfigParam("k2", "d2")
+            provider.set(param1, "v1")
+            provider.set(param2, "v2")
+
+            provider.observe(param1).test {
+                awaitItem() // initial
+
+                provider.clear()
+
+                val afterClear = awaitItem()
+                assertEquals("d1", afterClear.value)
+                assertEquals(ConfigValue.Source.DEFAULT, afterClear.source)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun clearDoesNotEmitForKeyNeverSet() =
+        runTest {
+            val provider = InMemoryConfigValueProvider()
+            val setParam = ConfigParam("set_key", "default_set")
+            val unsetParam = ConfigParam("unset_key", "default_unset")
+            provider.set(setParam, "value")
+
+            provider.observe(unsetParam).test {
+                awaitItem() // initial DEFAULT (key never set)
+
+                provider.clear()
+
+                // unset_key was not in storage — clear() must not emit for it
                 expectNoEvents()
 
                 cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // Parallel resetOverride of N keys must not lose any removals.
+    @Test
+    fun parallelResetOverrideOfNKeysLosesNoRemovals() =
+        runTest {
+            val n = 50
+            val provider = InMemoryConfigValueProvider()
+            val params = List(n) { i -> ConfigParam("pk$i", i) }
+            params.forEach { p -> provider.set(p, p.defaultValue + 1) }
+
+            params
+                .map { p ->
+                    launch { provider.resetOverride(p) }
+                }.forEach { it.join() }
+
+            params.forEach { p ->
+                assertNull(provider.get(p), "key ${p.key} should be absent after resetOverride")
             }
         }
 

--- a/core/src/commonTest/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProviderTest.kt
+++ b/core/src/commonTest/kotlin/dev/androidbroadcast/featured/InMemoryConfigValueProviderTest.kt
@@ -230,13 +230,83 @@ class InMemoryConfigValueProviderTest {
             provider.set(param2, "v2")
 
             provider.observe(param1).test {
-                awaitItem() // initial
+                awaitItem() // initial for param1
+
+                provider.observe(param2).test {
+                    awaitItem() // initial for param2
+
+                    provider.clear()
+
+                    // Both observers must receive their DEFAULT frame.
+                    val afterClear2 = awaitItem()
+                    assertEquals("d2", afterClear2.value)
+                    assertEquals(ConfigValue.Source.DEFAULT, afterClear2.source)
+
+                    cancelAndIgnoreRemainingEvents()
+                }
+
+                // Outer (param1) observer must also have received its DEFAULT frame.
+                val afterClear1 = awaitItem()
+                assertEquals("d1", afterClear1.value)
+                assertEquals(ConfigValue.Source.DEFAULT, afterClear1.source)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun observeAfterClearEmitsDefaultAsFirstFrame() =
+        runTest {
+            val provider = InMemoryConfigValueProvider()
+            val param = ConfigParam("after_clear_key", "my_default")
+            provider.set(param, "stored_value")
+
+            provider.clear()
+
+            // Subscriber attached AFTER clear() — must see DEFAULT as the first frame, not LOCAL.
+            provider.observe(param).test {
+                val first = awaitItem()
+                assertEquals("my_default", first.value)
+                assertEquals(ConfigValue.Source.DEFAULT, first.source)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun clearWithNoStoredKeysIsNoOp() =
+        runTest {
+            val provider = InMemoryConfigValueProvider()
+            val param = ConfigParam("any_key", "default")
+
+            provider.observe(param).test {
+                awaitItem() // initial DEFAULT
+
+                // clear() on empty storage must not emit and must not crash.
+                provider.clear()
+                expectNoEvents()
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun clearTwiceSecondIsNoOp() =
+        runTest {
+            val provider = InMemoryConfigValueProvider()
+            val param = ConfigParam("double_clear_key", "default")
+            provider.set(param, "value")
+
+            provider.observe(param).test {
+                awaitItem() // initial LOCAL
 
                 provider.clear()
+                val afterFirst = awaitItem()
+                assertEquals(ConfigValue.Source.DEFAULT, afterFirst.source)
 
-                val afterClear = awaitItem()
-                assertEquals("d1", afterClear.value)
-                assertEquals(ConfigValue.Source.DEFAULT, afterClear.source)
+                // Second clear — storage is already empty, must produce no emissions.
+                provider.clear()
+                expectNoEvents()
 
                 cancelAndIgnoreRemainingEvents()
             }

--- a/providers/nsuserdefaults/src/iosMain/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProvider.kt
+++ b/providers/nsuserdefaults/src/iosMain/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProvider.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import platform.Foundation.NSArray
 import platform.Foundation.NSUserDefaults
 
 /**
@@ -22,8 +23,16 @@ import platform.Foundation.NSUserDefaults
  * Supported value types: [String], [Int], [Long], [Float], [Double], [Boolean].
  * Attempting to read or write an unsupported type throws [IllegalArgumentException].
  *
- * Active [observe] flows receive updates whenever [set] or [resetOverride] is called for the
- * observed key. [clear] does not emit change signals — see its KDoc for details.
+ * Active [observe] flows receive updates whenever [set], [resetOverride], or [clear] is called.
+ * After [clear], observers for previously-set keys emit [ConfigValue.Source.DEFAULT].
+ *
+ * **Written-key index:** to scope [clear] to provider-owned keys only (avoiding destruction of
+ * foreign or system keys in the same suite), every [set] / [resetOverride]-write atomically adds
+ * or removes the param key in a persistent string-array index stored under [RESERVED_INDEX_KEY].
+ * [clear] reads the index, removes only those keys, and emits change signals for each one.
+ * The index may desync on crash between writes; this is self-healing — [get] never consults the
+ * index and always reads directly from [NSUserDefaults]. Setting or getting the reserved key
+ * itself throws [IllegalArgumentException].
  *
  * ```kotlin
  * val provider = NSUserDefaultsConfigValueProvider(suiteName = "com.example.app.flags")
@@ -49,10 +58,12 @@ public class NSUserDefaultsConfigValueProvider(
      *
      * @param param The configuration parameter to look up.
      * @return A [ConfigValue] with [ConfigValue.Source.LOCAL], or `null` if not present.
-     * @throws IllegalArgumentException if the type of [param] is not supported.
+     * @throws IllegalArgumentException if [param] key equals [RESERVED_INDEX_KEY] or if the
+     *   type of [param] is not supported.
      */
     @Suppress("UNCHECKED_CAST")
     override suspend fun <T : Any> get(param: ConfigParam<T>): ConfigValue<T>? {
+        requireNotReservedKey(param.key)
         val key = param.key
         // NSUserDefaults returns a default (0/false/"") when a key is absent, so we must
         // check object(forKey:) to distinguish "not set" from "set to default value".
@@ -74,14 +85,19 @@ public class NSUserDefaultsConfigValueProvider(
     /**
      * Persists [value] as a local override for [param] and notifies active [observe] flows.
      *
+     * Also records [param] key in the internal written-key index so that [clear] can scope
+     * its deletion to provider-owned keys.
+     *
      * @param param The configuration parameter to override.
      * @param value The value to persist.
-     * @throws IllegalArgumentException if the type of [param] is not supported.
+     * @throws IllegalArgumentException if [param] key equals [RESERVED_INDEX_KEY] or if the
+     *   type of [param] is not supported.
      */
     override suspend fun <T : Any> set(
         param: ConfigParam<T>,
         value: T,
     ) {
+        requireNotReservedKey(param.key)
         val key = param.key
         when (value) {
             is Boolean -> defaults.setBool(value, forKey = key)
@@ -92,11 +108,14 @@ public class NSUserDefaultsConfigValueProvider(
             is String -> defaults.setObject(value, forKey = key)
             else -> throw IllegalArgumentException("Unsupported type: ${param.valueType}")
         }
+        addToIndex(key)
         changedKeyFlow.tryEmit(key)
     }
 
     /**
      * Removes the persisted override for [param] and notifies active [observe] flows.
+     *
+     * Also removes [param] key from the internal written-key index.
      *
      * After this call, [get] returns `null` and [ConfigValues] falls back to the remote
      * provider or [ConfigParam.defaultValue].
@@ -105,23 +124,32 @@ public class NSUserDefaultsConfigValueProvider(
      */
     override suspend fun <T : Any> resetOverride(param: ConfigParam<T>) {
         defaults.removeObjectForKey(param.key)
+        removeFromIndex(param.key)
         changedKeyFlow.tryEmit(param.key)
     }
 
     /**
-     * Removes all persisted overrides by removing all keys from this provider's store.
+     * Removes all provider-owned keys and notifies active [observe] flows for each one.
      *
-     * After this call, [get] returns `null` for every parameter that was previously set,
-     * and [ConfigValues] falls back to the remote provider or [ConfigParam.defaultValue].
+     * Only keys tracked in the internal written-key index (stored under [RESERVED_INDEX_KEY])
+     * are deleted — foreign keys written directly into the same NSUserDefaults suite by other
+     * code are not touched. The index itself is also deleted.
      *
-     * Unlike [resetOverride], this does **not** emit change signals to active [observe] flows.
-     * Callers that need reactive updates after a bulk clear should call [resetOverride]
-     * per parameter instead.
+     * After this call, [get] returns `null` for every parameter that was previously set via
+     * this provider, and active [observe] flows emit [ConfigValue.Source.DEFAULT].
+     *
+     * **Note:** NSUserDefaults is not transactional. A crash between the value write and the
+     * index write in [set] can leave the index out of sync; the self-healing invariant is that
+     * [get] never reads the index and always queries NSUserDefaults directly.
      */
     override suspend fun clear() {
-        val dict = defaults.dictionaryRepresentation()
-        for (key in dict.keys) {
-            defaults.removeObjectForKey(key as String)
+        val writtenKeys = readIndex()
+        for (key in writtenKeys) {
+            defaults.removeObjectForKey(key)
+        }
+        defaults.removeObjectForKey(RESERVED_INDEX_KEY)
+        for (key in writtenKeys) {
+            changedKeyFlow.tryEmit(key)
         }
     }
 
@@ -131,15 +159,26 @@ public class NSUserDefaultsConfigValueProvider(
      * Conforms to [LocalConfigValueProvider.observe] contract: the flow always emits immediately
      * upon collection — [ConfigValue.Source.LOCAL] when a value is persisted,
      * [ConfigValue.Source.DEFAULT] wrapping [ConfigParam.defaultValue] otherwise. It then emits
-     * again whenever [set] or [resetOverride] is called for the same key. Consecutive identical
-     * values are deduplicated via `distinctUntilChanged`.
+     * again whenever [set], [resetOverride], or [clear] is called for the same key. Consecutive
+     * identical values are deduplicated via `distinctUntilChanged`.
      *
      * @param param The configuration parameter to observe.
      * @return A cold [Flow] that completes when the collector's scope is cancelled.
      */
     override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
         flow {
-            emit(get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT))
+            // Wrap initial get in the same error-isolation as the reactive path so that
+            // invalid param keys (e.g. the reserved index key) emit DEFAULT rather than
+            // terminating the flow with an exception.
+            val initial =
+                try {
+                    get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
+                } catch (ce: CancellationException) {
+                    throw ce
+                } catch (_: Throwable) {
+                    ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
+                }
+            emit(initial)
             emitAll(
                 changedKeyFlow
                     .filter { key -> key == param.key }
@@ -167,5 +206,46 @@ public class NSUserDefaultsConfigValueProvider(
         if (suiteName != null) {
             NSUserDefaults.standardUserDefaults.removeSuiteNamed(suiteName)
         }
+    }
+
+    // --- Written-key index helpers ---
+
+    private fun readIndex(): List<String> {
+        @Suppress("UNCHECKED_CAST")
+        val array = defaults.arrayForKey(RESERVED_INDEX_KEY) as? NSArray ?: return emptyList()
+        return (0 until array.count.toInt()).mapNotNull { i ->
+            array.objectAtIndex(i.toULong()) as? String
+        }
+    }
+
+    private fun addToIndex(key: String) {
+        val current = readIndex().toMutableList()
+        if (!current.contains(key)) {
+            current.add(key)
+        }
+        defaults.setObject(current, forKey = RESERVED_INDEX_KEY)
+    }
+
+    private fun removeFromIndex(key: String) {
+        val current = readIndex().toMutableList()
+        current.remove(key)
+        defaults.setObject(current, forKey = RESERVED_INDEX_KEY)
+    }
+
+    private fun requireNotReservedKey(key: String) {
+        require(key != RESERVED_INDEX_KEY) {
+            "Key '$key' is reserved for internal use by NSUserDefaultsConfigValueProvider " +
+                "and must not be used as a ConfigParam key."
+        }
+    }
+
+    public companion object {
+        /**
+         * NSUserDefaults key used to store the index of keys written by this provider.
+         *
+         * This key is reserved and must not be used as a [ConfigParam] key. Reading or writing
+         * a [ConfigParam] whose key equals this constant throws [IllegalArgumentException].
+         */
+        public const val RESERVED_INDEX_KEY: String = "dev.androidbroadcast.featured.written_keys"
     }
 }

--- a/providers/nsuserdefaults/src/iosMain/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProvider.kt
+++ b/providers/nsuserdefaults/src/iosMain/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProvider.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import platform.Foundation.NSArray
 import platform.Foundation.NSUserDefaults
 
@@ -34,6 +36,10 @@ import platform.Foundation.NSUserDefaults
  * index and always reads directly from [NSUserDefaults]. Setting or getting the reserved key
  * itself throws [IllegalArgumentException].
  *
+ * **Concurrency:** in-process index read-modify-write operations (in [addToIndex], [removeFromIndex],
+ * and [clear]) are serialized via an internal [Mutex]. Cross-process access or crash-interrupted
+ * writes may still desync the index; the self-healing invariant above covers that case.
+ *
  * ```kotlin
  * val provider = NSUserDefaultsConfigValueProvider(suiteName = "com.example.app.flags")
  * val configValues = ConfigValues(localProvider = provider)
@@ -52,6 +58,7 @@ public class NSUserDefaultsConfigValueProvider(
         }
 
     private val changedKeyFlow = MutableSharedFlow<String>(extraBufferCapacity = Int.MAX_VALUE)
+    private val indexMutex = Mutex()
 
     /**
      * Returns the persisted value for [param], or `null` if it has not been set.
@@ -123,6 +130,7 @@ public class NSUserDefaultsConfigValueProvider(
      * @param param The configuration parameter whose override should be cleared.
      */
     override suspend fun <T : Any> resetOverride(param: ConfigParam<T>) {
+        requireNotReservedKey(param.key)
         defaults.removeObjectForKey(param.key)
         removeFromIndex(param.key)
         changedKeyFlow.tryEmit(param.key)
@@ -143,11 +151,15 @@ public class NSUserDefaultsConfigValueProvider(
      * [get] never reads the index and always queries NSUserDefaults directly.
      */
     override suspend fun clear() {
-        val writtenKeys = readIndex()
-        for (key in writtenKeys) {
-            defaults.removeObjectForKey(key)
-        }
-        defaults.removeObjectForKey(RESERVED_INDEX_KEY)
+        val writtenKeys =
+            indexMutex.withLock {
+                val keys = readIndex()
+                for (key in keys) {
+                    defaults.removeObjectForKey(key)
+                }
+                defaults.removeObjectForKey(RESERVED_INDEX_KEY)
+                keys
+            }
         for (key in writtenKeys) {
             changedKeyFlow.tryEmit(key)
         }
@@ -218,18 +230,22 @@ public class NSUserDefaultsConfigValueProvider(
         }
     }
 
-    private fun addToIndex(key: String) {
-        val current = readIndex().toMutableList()
-        if (!current.contains(key)) {
-            current.add(key)
+    private suspend fun addToIndex(key: String) {
+        indexMutex.withLock {
+            val current = readIndex().toMutableList()
+            if (!current.contains(key)) {
+                current.add(key)
+            }
+            defaults.setObject(current, forKey = RESERVED_INDEX_KEY)
         }
-        defaults.setObject(current, forKey = RESERVED_INDEX_KEY)
     }
 
-    private fun removeFromIndex(key: String) {
-        val current = readIndex().toMutableList()
-        current.remove(key)
-        defaults.setObject(current, forKey = RESERVED_INDEX_KEY)
+    private suspend fun removeFromIndex(key: String) {
+        indexMutex.withLock {
+            val current = readIndex().toMutableList()
+            current.remove(key)
+            defaults.setObject(current, forKey = RESERVED_INDEX_KEY)
+        }
     }
 
     private fun requireNotReservedKey(key: String) {

--- a/providers/nsuserdefaults/src/iosMain/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProvider.kt
+++ b/providers/nsuserdefaults/src/iosMain/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProvider.kt
@@ -36,9 +36,13 @@ import platform.Foundation.NSUserDefaults
  * index and always reads directly from [NSUserDefaults]. Setting or getting the reserved key
  * itself throws [IllegalArgumentException].
  *
- * **Concurrency:** in-process index read-modify-write operations (in [addToIndex], [removeFromIndex],
- * and [clear]) are serialized via an internal [Mutex]. Cross-process access or crash-interrupted
- * writes may still desync the index; the self-healing invariant above covers that case.
+ * **Concurrency:** in-process [set] / [resetOverride] serialize their NSUserDefaults value-write
+ * together with the corresponding index update under [indexMutex], the same mutex used by [clear].
+ * This closes the window where a key written by [set] could escape [clear]'s index snapshot.
+ * Note that NSUserDefaults [setObject] has no error return — a silent platform failure can desync
+ * the index without a crash; [get] remains unaffected as it reads directly from NSUserDefaults.
+ * Cross-process access or crash-interrupted writes may still desync the index; the self-healing
+ * invariant above covers that case.
  *
  * ```kotlin
  * val provider = NSUserDefaultsConfigValueProvider(suiteName = "com.example.app.flags")
@@ -106,16 +110,24 @@ public class NSUserDefaultsConfigValueProvider(
     ) {
         requireNotReservedKey(param.key)
         val key = param.key
-        when (value) {
-            is Boolean -> defaults.setBool(value, forKey = key)
-            is Int -> defaults.setInteger(value.toLong(), forKey = key)
-            is Long -> defaults.setInteger(value, forKey = key)
-            is Double -> defaults.setDouble(value, forKey = key)
-            is Float -> defaults.setFloat(value, forKey = key)
-            is String -> defaults.setObject(value, forKey = key)
-            else -> throw IllegalArgumentException("Unsupported type: ${param.valueType}")
+        // Value-write and index-update share the mutex with clear() to prevent a race where
+        // a freshly-written key escapes clear()'s index snapshot.
+        indexMutex.withLock {
+            when (value) {
+                is Boolean -> defaults.setBool(value, forKey = key)
+                is Int -> defaults.setInteger(value.toLong(), forKey = key)
+                is Long -> defaults.setInteger(value, forKey = key)
+                is Double -> defaults.setDouble(value, forKey = key)
+                is Float -> defaults.setFloat(value, forKey = key)
+                is String -> defaults.setObject(value, forKey = key)
+                else -> throw IllegalArgumentException("Unsupported type: ${param.valueType}")
+            }
+            val current = readIndex().toMutableList()
+            if (!current.contains(key)) {
+                current.add(key)
+            }
+            defaults.setObject(current, forKey = RESERVED_INDEX_KEY)
         }
-        addToIndex(key)
         changedKeyFlow.tryEmit(key)
     }
 
@@ -131,9 +143,15 @@ public class NSUserDefaultsConfigValueProvider(
      */
     override suspend fun <T : Any> resetOverride(param: ConfigParam<T>) {
         requireNotReservedKey(param.key)
-        defaults.removeObjectForKey(param.key)
-        removeFromIndex(param.key)
-        changedKeyFlow.tryEmit(param.key)
+        val key = param.key
+        // Remove and index-update share the mutex with set()/clear() to close the in-process race.
+        indexMutex.withLock {
+            defaults.removeObjectForKey(key)
+            val current = readIndex().toMutableList()
+            current.remove(key)
+            defaults.setObject(current, forKey = RESERVED_INDEX_KEY)
+        }
+        changedKeyFlow.tryEmit(key)
     }
 
     /**
@@ -154,15 +172,11 @@ public class NSUserDefaultsConfigValueProvider(
         val writtenKeys =
             indexMutex.withLock {
                 val keys = readIndex()
-                for (key in keys) {
-                    defaults.removeObjectForKey(key)
-                }
+                keys.forEach { key -> defaults.removeObjectForKey(key) }
                 defaults.removeObjectForKey(RESERVED_INDEX_KEY)
                 keys
             }
-        for (key in writtenKeys) {
-            changedKeyFlow.tryEmit(key)
-        }
+        writtenKeys.forEach { key -> changedKeyFlow.tryEmit(key) }
     }
 
     /**
@@ -174,14 +188,20 @@ public class NSUserDefaultsConfigValueProvider(
      * again whenever [set], [resetOverride], or [clear] is called for the same key. Consecutive
      * identical values are deduplicated via `distinctUntilChanged`.
      *
+     * The reserved-key guard ([RESERVED_INDEX_KEY]) is checked eagerly at construction time so
+     * that passing an invalid [param] throws at the call site rather than being swallowed inside
+     * the flow's error-isolation handler.
+     *
      * @param param The configuration parameter to observe.
      * @return A cold [Flow] that completes when the collector's scope is cancelled.
+     * @throws IllegalArgumentException if [param] key equals [RESERVED_INDEX_KEY].
      */
-    override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> =
-        flow {
+    override fun <T : Any> observe(param: ConfigParam<T>): Flow<ConfigValue<T>> {
+        requireNotReservedKey(param.key)
+        return flow {
             // Wrap initial get in the same error-isolation as the reactive path so that
-            // invalid param keys (e.g. the reserved index key) emit DEFAULT rather than
-            // terminating the flow with an exception.
+            // other invalid param keys emit DEFAULT rather than terminating the flow with
+            // an exception.
             val initial =
                 try {
                     get(param) ?: ConfigValue(param.defaultValue, ConfigValue.Source.DEFAULT)
@@ -207,6 +227,7 @@ public class NSUserDefaultsConfigValueProvider(
                     },
             )
         }.distinctUntilChanged()
+    }
 
     /**
      * Removes the entire NSUserDefaults suite, cleaning up all stored data.
@@ -227,24 +248,6 @@ public class NSUserDefaultsConfigValueProvider(
         val array = defaults.arrayForKey(RESERVED_INDEX_KEY) as? NSArray ?: return emptyList()
         return (0 until array.count.toInt()).mapNotNull { i ->
             array.objectAtIndex(i.toULong()) as? String
-        }
-    }
-
-    private suspend fun addToIndex(key: String) {
-        indexMutex.withLock {
-            val current = readIndex().toMutableList()
-            if (!current.contains(key)) {
-                current.add(key)
-            }
-            defaults.setObject(current, forKey = RESERVED_INDEX_KEY)
-        }
-    }
-
-    private suspend fun removeFromIndex(key: String) {
-        indexMutex.withLock {
-            val current = readIndex().toMutableList()
-            current.remove(key)
-            defaults.setObject(current, forKey = RESERVED_INDEX_KEY)
         }
     }
 

--- a/providers/nsuserdefaults/src/iosTest/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProviderTest.kt
+++ b/providers/nsuserdefaults/src/iosTest/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProviderTest.kt
@@ -3,6 +3,8 @@ package dev.androidbroadcast.featured.nsuserdefaults
 import app.cash.turbine.test
 import dev.androidbroadcast.featured.ConfigParam
 import dev.androidbroadcast.featured.ConfigValue
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import platform.Foundation.NSUserDefaults
@@ -125,6 +127,15 @@ class NSUserDefaultsConfigValueProviderTest {
                 assertEquals("my_default", emission.value)
                 assertEquals(ConfigValue.Source.DEFAULT, emission.source)
                 cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun resetOverrideWithReservedKeyThrows() =
+        runTest {
+            val param = ConfigParam(NSUserDefaultsConfigValueProvider.RESERVED_INDEX_KEY, "default")
+            assertFailsWith<IllegalArgumentException> {
+                provider.resetOverride(param)
             }
         }
 
@@ -269,6 +280,34 @@ class NSUserDefaultsConfigValueProviderTest {
                 assertEquals(ConfigValue.Source.DEFAULT, afterReset.source)
 
                 cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // --- index atomicity ---
+
+    @Test
+    fun parallelSetsAllKeysAppearedInIndex() =
+        runTest {
+            val keyCount = 20
+            val params = (0 until keyCount).map { i -> ConfigParam("parallel_key_$i", false) }
+
+            coroutineScope {
+                params
+                    .map { param ->
+                        async { provider.set(param, true) }
+                    }.forEach { it.await() }
+            }
+
+            // Every key set concurrently must be present in the index so clear() can remove them.
+            params.forEach { param ->
+                assertEquals(
+                    expected = ConfigValue(true, ConfigValue.Source.LOCAL),
+                    actual = provider.get(param),
+                )
+            }
+            provider.clear()
+            params.forEach { param ->
+                assertNull(provider.get(param))
             }
         }
 }

--- a/providers/nsuserdefaults/src/iosTest/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProviderTest.kt
+++ b/providers/nsuserdefaults/src/iosTest/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProviderTest.kt
@@ -5,10 +5,12 @@ import dev.androidbroadcast.featured.ConfigParam
 import dev.androidbroadcast.featured.ConfigValue
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import platform.Foundation.NSUserDefaults
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 class NSUserDefaultsConfigValueProviderTest {
@@ -28,14 +30,14 @@ class NSUserDefaultsConfigValueProviderTest {
     // --- get ---
 
     @Test
-    fun `get returns null when key not set`() =
+    fun getReturnsNullWhenKeyNotSet() =
         runTest {
             val param = ConfigParam("missing_key", false)
             assertNull(provider.get(param))
         }
 
     @Test
-    fun `get returns stored Boolean value`() =
+    fun getReturnsStoredBooleanValue() =
         runTest {
             val param = ConfigParam("bool_key", false)
             provider.set(param, true)
@@ -44,7 +46,7 @@ class NSUserDefaultsConfigValueProviderTest {
         }
 
     @Test
-    fun `get returns stored Int value`() =
+    fun getReturnsStoredIntValue() =
         runTest {
             val param = ConfigParam("int_key", 0)
             provider.set(param, 42)
@@ -53,7 +55,7 @@ class NSUserDefaultsConfigValueProviderTest {
         }
 
     @Test
-    fun `get returns stored Long value`() =
+    fun getReturnsStoredLongValue() =
         runTest {
             val param = ConfigParam("long_key", 0L)
             provider.set(param, 123456789L)
@@ -62,7 +64,7 @@ class NSUserDefaultsConfigValueProviderTest {
         }
 
     @Test
-    fun `get returns stored Double value`() =
+    fun getReturnsStoredDoubleValue() =
         runTest {
             val param = ConfigParam("double_key", 0.0)
             provider.set(param, 3.14)
@@ -71,7 +73,7 @@ class NSUserDefaultsConfigValueProviderTest {
         }
 
     @Test
-    fun `get returns stored Float value`() =
+    fun getReturnsStoredFloatValue() =
         runTest {
             val param = ConfigParam("float_key", 0f)
             provider.set(param, 2.5f)
@@ -80,7 +82,7 @@ class NSUserDefaultsConfigValueProviderTest {
         }
 
     @Test
-    fun `get returns stored String value`() =
+    fun getReturnsStoredStringValue() =
         runTest {
             val param = ConfigParam("string_key", "")
             provider.set(param, "hello")
@@ -88,10 +90,48 @@ class NSUserDefaultsConfigValueProviderTest {
             assertEquals(ConfigValue("hello", ConfigValue.Source.LOCAL), result)
         }
 
+    // --- reserved key protection ---
+
+    @Test
+    fun getWithReservedKeyThrows() =
+        runTest {
+            val param = ConfigParam(NSUserDefaultsConfigValueProvider.RESERVED_INDEX_KEY, "default")
+            assertFailsWith<IllegalArgumentException> {
+                provider.get(param)
+            }
+        }
+
+    @Test
+    fun setWithReservedKeyThrows() =
+        runTest {
+            val param = ConfigParam(NSUserDefaultsConfigValueProvider.RESERVED_INDEX_KEY, "default")
+            assertFailsWith<IllegalArgumentException> {
+                provider.set(param, "value")
+            }
+        }
+
+    @Test
+    fun reservedKeyIsInvisibleViaObserve() =
+        runTest {
+            // The reserved key must not surface as a provider value — observe emits DEFAULT
+            val param = ConfigParam(NSUserDefaultsConfigValueProvider.RESERVED_INDEX_KEY, "my_default")
+            // Manually write something at the reserved key to simulate index presence
+            val defaults = NSUserDefaults(suiteName = suiteName)
+            defaults.setObject(listOf("some_key"), forKey = NSUserDefaultsConfigValueProvider.RESERVED_INDEX_KEY)
+
+            provider.observe(param).test {
+                val emission = awaitItem()
+                // get() throws for the reserved key, so observe must emit DEFAULT (error path)
+                assertEquals("my_default", emission.value)
+                assertEquals(ConfigValue.Source.DEFAULT, emission.source)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     // --- resetOverride ---
 
     @Test
-    fun `resetOverride makes get return null`() =
+    fun resetOverrideMakesGetReturnNull() =
         runTest {
             val param = ConfigParam("reset_key", false)
             provider.set(param, true)
@@ -102,7 +142,7 @@ class NSUserDefaultsConfigValueProviderTest {
     // --- clear ---
 
     @Test
-    fun `clear removes all values`() =
+    fun clearRemovesProviderOwnedValues() =
         runTest {
             val boolParam = ConfigParam("clear_bool", false)
             val strParam = ConfigParam("clear_str", "")
@@ -113,10 +153,69 @@ class NSUserDefaultsConfigValueProviderTest {
             assertNull(provider.get(strParam))
         }
 
+    @Test
+    fun clearDoesNotTouchForeignKeyInSameSuite() =
+        runTest {
+            // A foreign key written directly into the same suite must survive clear().
+            val foreignKey = "foreign.key.written.directly"
+            val defaults = NSUserDefaults(suiteName = suiteName)
+            defaults.setObject("foreign_value", forKey = foreignKey)
+
+            val ownedParam = ConfigParam("owned_key", "default")
+            provider.set(ownedParam, "owned_value")
+
+            provider.clear()
+
+            // Provider-owned key is gone
+            assertNull(provider.get(ownedParam))
+            // Foreign key survives — clear() only removes index-tracked keys
+            assertEquals("foreign_value", defaults.objectForKey(foreignKey))
+        }
+
+    @Test
+    fun clearNotifiesActiveObserversWithDefault() =
+        runTest {
+            val param = ConfigParam("obs_clear_key", "my_default")
+            provider.set(param, "stored")
+
+            provider.observe(param).test {
+                // Initial LOCAL emission
+                val initial = awaitItem()
+                assertEquals("stored", initial.value)
+                assertEquals(ConfigValue.Source.LOCAL, initial.source)
+
+                provider.clear()
+
+                val afterClear = awaitItem()
+                assertEquals("my_default", afterClear.value)
+                assertEquals(ConfigValue.Source.DEFAULT, afterClear.source)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun clearIndexSurvivesAcrossProviderInstances() =
+        runTest {
+            // Set a value via the original provider so the key is indexed
+            val param = ConfigParam("persist_key", "default")
+            provider.set(param, "value")
+
+            // Create a second provider over the same suite (simulates app restart)
+            val provider2 = NSUserDefaultsConfigValueProvider(suiteName = suiteName)
+
+            // clear() on provider2 must still find and remove the key
+            provider2.clear()
+
+            // Both provider instances agree the key is gone
+            assertNull(provider.get(param))
+            assertNull(provider2.get(param))
+        }
+
     // --- observe ---
 
     @Test
-    fun `observe emits current value immediately when set`() =
+    fun observeEmitsCurrentValueImmediatelyWhenSet() =
         runTest {
             val param = ConfigParam("observe_key", false)
             provider.set(param, true)
@@ -125,16 +224,14 @@ class NSUserDefaultsConfigValueProviderTest {
         }
 
     @Test
-    fun `observe emits updated value after set`() =
+    fun observeEmitsUpdatedValueAfterSet() =
         runTest {
             val param = ConfigParam("observe_update_key", 0)
             provider.set(param, 1)
 
             provider.observe(param).test {
-                // First emission: current stored value
                 assertEquals(ConfigValue(1, ConfigValue.Source.LOCAL), awaitItem())
 
-                // Reactive emission: new value after set
                 provider.set(param, 99)
                 assertEquals(ConfigValue(99, ConfigValue.Source.LOCAL), awaitItem())
 
@@ -143,7 +240,7 @@ class NSUserDefaultsConfigValueProviderTest {
         }
 
     @Test
-    fun `observe emits DEFAULT immediately when key has never been written`() =
+    fun observeEmitsDefaultImmediatelyWhenKeyHasNeverBeenWritten() =
         runTest {
             val param = ConfigParam("never_written_bool", false)
 
@@ -155,15 +252,13 @@ class NSUserDefaultsConfigValueProviderTest {
             }
         }
 
-    // G5: resetOverride after set → observe emits DEFAULT-sourced frame.
     @Test
-    fun `observe emits DEFAULT after resetOverride when value cleared`() =
+    fun observeEmitsDefaultAfterResetOverrideWhenValueCleared() =
         runTest {
             val param = ConfigParam("reset_obs_key", false)
             provider.set(param, true)
 
             provider.observe(param).test {
-                // Initial LOCAL frame
                 val initial = awaitItem()
                 assertEquals(true, initial.value)
                 assertEquals(ConfigValue.Source.LOCAL, initial.source)

--- a/providers/nsuserdefaults/src/iosTest/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProviderTest.kt
+++ b/providers/nsuserdefaults/src/iosTest/kotlin/dev/androidbroadcast/featured/nsuserdefaults/NSUserDefaultsConfigValueProviderTest.kt
@@ -113,22 +113,14 @@ class NSUserDefaultsConfigValueProviderTest {
         }
 
     @Test
-    fun reservedKeyIsInvisibleViaObserve() =
-        runTest {
-            // The reserved key must not surface as a provider value — observe emits DEFAULT
-            val param = ConfigParam(NSUserDefaultsConfigValueProvider.RESERVED_INDEX_KEY, "my_default")
-            // Manually write something at the reserved key to simulate index presence
-            val defaults = NSUserDefaults(suiteName = suiteName)
-            defaults.setObject(listOf("some_key"), forKey = NSUserDefaultsConfigValueProvider.RESERVED_INDEX_KEY)
-
-            provider.observe(param).test {
-                val emission = awaitItem()
-                // get() throws for the reserved key, so observe must emit DEFAULT (error path)
-                assertEquals("my_default", emission.value)
-                assertEquals(ConfigValue.Source.DEFAULT, emission.source)
-                cancelAndIgnoreRemainingEvents()
-            }
+    fun reservedKeyIsInvisibleViaObserve() {
+        // observe() now guards the reserved key eagerly before building the flow, so it throws
+        // at the call site rather than emitting DEFAULT on first collection.
+        val param = ConfigParam(NSUserDefaultsConfigValueProvider.RESERVED_INDEX_KEY, "my_default")
+        assertFailsWith<IllegalArgumentException> {
+            provider.observe(param)
         }
+    }
 
     @Test
     fun resetOverrideWithReservedKeyThrows() =
@@ -281,6 +273,74 @@ class NSUserDefaultsConfigValueProviderTest {
 
                 cancelAndIgnoreRemainingEvents()
             }
+        }
+
+    // --- eager reserved-key guard in observe() ---
+
+    @Test
+    fun observeWithReservedKeyThrowsAtConstruction() {
+        val param = ConfigParam(NSUserDefaultsConfigValueProvider.RESERVED_INDEX_KEY, "default")
+        // requireNotReservedKey is called before the flow builder, so the exception is thrown
+        // at the call site of observe(), not deferred until the first collection attempt.
+        assertFailsWith<IllegalArgumentException> {
+            provider.observe(param)
+        }
+    }
+
+    // --- clear() edge cases ---
+
+    @Test
+    fun clearOnFreshProviderProducesNoCrashAndNoEmissions() =
+        runTest {
+            val param = ConfigParam("fresh_clear_key", "default")
+            // Observe before any set to attach a subscriber.
+            provider.observe(param).test {
+                awaitItem() // initial DEFAULT
+
+                // clear() on a provider with empty index must not crash and must emit nothing.
+                provider.clear()
+                expectNoEvents()
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun clearTwiceSecondIsNoOp() =
+        runTest {
+            val param = ConfigParam("double_clear_key", "initial")
+            provider.set(param, "stored")
+
+            provider.observe(param).test {
+                awaitItem() // initial LOCAL
+
+                provider.clear()
+                val afterFirst = awaitItem()
+                assertEquals(ConfigValue.Source.DEFAULT, afterFirst.source)
+
+                // Second clear — index is empty, must produce no emissions and no crash.
+                provider.clear()
+                expectNoEvents()
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // --- index self-heal: direct NSUserDefaults write is readable via get() ---
+
+    @Test
+    fun keyWrittenDirectlyToSuiteIsReadableViaGet() =
+        runTest {
+            // A String value written directly to the suite bypasses the provider's index.
+            // get() must still return it because get() reads from NSUserDefaults directly,
+            // not from the written-key index.
+            val directDefaults = NSUserDefaults(suiteName = suiteName)
+            val param = ConfigParam("direct_write_key", "none")
+            directDefaults.setObject("direct_value", forKey = param.key)
+
+            val result = provider.get(param)
+            assertEquals("direct_value", result?.value)
+            assertEquals(ConfigValue.Source.LOCAL, result?.source)
         }
 
     // --- index atomicity ---


### PR DESCRIPTION
Closes #257

## What
- `clear()` now notifies active `observe()` flows in both `NSUserDefaultsConfigValueProvider` and `InMemoryConfigValueProvider` — observers emit the DEFAULT-sourced value for every previously stored key (builds on the #252 contract).
- **NSUserDefaults `clear()` scope fix**: deletion is now limited to provider-written keys tracked in a persistent index (`dev.androidbroadcast.featured.written_keys`); previously `clear()` wiped the entire suite — catastrophic for `standardUserDefaults`. Foreign keys in the same suite survive (tested).
- Reserved-key hardening: `set`/`get`/`resetOverride` throw `IllegalArgumentException` for the index key; `observe()` checks eagerly at construction. In-process index updates and value writes are serialized via a `Mutex` (closes the set/clear race); crash/quota desync remains a documented platform limitation with self-heal (reads never consult the index).
- `InMemoryConfigValueProvider`: storage migrated to `AtomicReference` with atomic `exchange` in `clear()` (no lost updates under parallel `resetOverride` from Reset All, no TOCTOU between snapshot and swap); change signals aligned to `tryEmit` + unbounded buffer.

## Breaking / behavioral
- `clear()` now emits change notifications (both providers).
- NSUserDefaults `clear()` no longer removes keys it did not write.

## Verification
- 25+ new/updated tests: iOS simulator suite for nsuserdefaults (clear-notify, foreign-key survival, reserved-key guards, index persistence across instances, parallel index integrity, double-clear, empty-clear), core InMemory (clear-notify for multiple observers, subscriber-after-clear, parallel reset, batch emissions). `:core:koverVerify` ≥90%.
- finalize PASS (review loop incl. convergent TOCTOU/race fixes), acceptance VERIFIED. Local assemble gate per #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)