### PR TITLE
Use full bundleReleaseAar task name in plugin test fixture

### DIFF
--- a/featured-gradle-plugin/src/test/kotlin/dev/androidbroadcast/featured/gradle/FeaturedPluginLibraryIntegrationTest.kt
+++ b/featured-gradle-plugin/src/test/kotlin/dev/androidbroadcast/featured/gradle/FeaturedPluginLibraryIntegrationTest.kt
@@ -72,10 +72,10 @@ class FeaturedPluginLibraryIntegrationTest {
     }
 
     @Test
-    fun `bundleRelease wires consumer proguard rules and completes successfully`() {
+    fun `bundleReleaseAar wires consumer proguard rules and completes successfully`() {
         val result =
             gradleRunner(projectDir)
-                .withArguments("bundleRelease", "--stacktrace")
+                .withArguments("bundleReleaseAar", "--stacktrace")
                 .build()
 
         // generateFeaturedProguardRules must have run as part of the library release build.
@@ -84,31 +84,33 @@ class FeaturedPluginLibraryIntegrationTest {
             proguardOutcome == TaskOutcome.SUCCESS ||
                 proguardOutcome == TaskOutcome.UP_TO_DATE ||
                 proguardOutcome == TaskOutcome.FROM_CACHE,
-            "Expected :generateFeaturedProguardRules to participate in bundleRelease, got $proguardOutcome\n${result.output}",
+            "Expected :generateFeaturedProguardRules to participate in bundleReleaseAar, got $proguardOutcome\n${result.output}",
         )
 
-        val bundleOutcome = result.task(":bundleRelease")?.outcome
+        val bundleOutcome = result.task(":bundleReleaseAar")?.outcome
         assertTrue(
             bundleOutcome == TaskOutcome.SUCCESS || bundleOutcome == TaskOutcome.UP_TO_DATE,
-            "Expected :bundleRelease to succeed or be up-to-date, got $bundleOutcome\n${result.output}",
+            "Expected :bundleReleaseAar to succeed or be up-to-date, got $bundleOutcome\n${result.output}",
         )
 
         // Verify the generated rules appear in the AAR's consumer proguard intermediates.
-        // AGP writes consumer ProGuard rules to this path before packaging them in the AAR.
-        val consumerProguardDir = projectDir.resolve("build/intermediates/consumer_proguard_dir/release")
-        assertTrue(
-            consumerProguardDir.exists(),
-            "Expected consumer proguard intermediate dir to exist at ${consumerProguardDir.path}",
-        )
+        // AGP 9.x merges consumer ProGuard rules into a single file via MergeConsumerProguardFilesTask.
+        // The output lands at: build/intermediates/merged_consumer_proguard_file/release/<taskName>/proguard.txt
+        // Older AGP used consumer_proguard_dir/release/ (directory with per-lib subdirs).
+        // We search both roots so the test survives across AGP versions.
+        val mergedRoot = projectDir.resolve("build/intermediates/merged_consumer_proguard_file/release")
+        val legacyDir = projectDir.resolve("build/intermediates/consumer_proguard_dir/release")
 
-        val consumerProguardFiles =
-            consumerProguardDir
-                .walkTopDown()
+        val consumerProguardFiles: List<File> =
+            sequenceOf(mergedRoot, legacyDir)
+                .filter { it.isDirectory }
+                .flatMap { it.walkTopDown() }
                 .filter { it.isFile && (it.name.endsWith(".pro") || it.name == "proguard.txt") }
                 .toList()
         assertTrue(
             consumerProguardFiles.isNotEmpty(),
-            "Expected at least one consumer proguard file (.pro or proguard.txt) under ${consumerProguardDir.path}",
+            "Expected consumer ProGuard files under ${mergedRoot.path} or ${legacyDir.path}, " +
+                "but neither location was populated.\n${result.output}",
         )
 
         val combinedContent = consumerProguardFiles.joinToString("\n") { it.readText() }


### PR DESCRIPTION
Closes #262

## What
- `bundleRelease` → `bundleReleaseAar` in `FeaturedPluginLibraryIntegrationTest`: the abbreviation became ambiguous under Gradle 9.4.1 (`bundleReleaseAar` vs `bundleReleaseLocalLintAar`).
- The same test's consumer-ProGuard assertion updated for AGP 9.x: merged output now lives at `merged_consumer_proguard_file/...` (old `consumer_proguard_dir/...` is also still walked for compatibility); the `-assumevalues` content assertion is unchanged.
- Audited all other TestKit `withArguments` calls — no other ambiguous abbreviations.

## Verification
- Full plugin suite: 279/279 green (the previously failing test now passes); spotless clean. finalize (lean, test-only diff): code-reviewer PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)