### PR TITLE
Route debug screen diagnostics through onError callback

### DIFF
--- a/featured-debug-ui/src/commonMain/kotlin/dev/androidbroadcast/featured/debugui/FeatureFlagsDebugScreen.kt
+++ b/featured-debug-ui/src/commonMain/kotlin/dev/androidbroadcast/featured/debugui/FeatureFlagsDebugScreen.kt
@@ -97,8 +97,9 @@ import kotlin.coroutines.cancellation.CancellationException
  *   override / reset operation. The screen recovers from all these errors without
  *   crashing; this callback is the hook to observe or log them.
  *
- *   Default behavior: prints the full stack trace to stdout via [println], which is the
- *   same as the pre-#268 behavior.
+ *   Default behavior: prints the full stack trace to stdout via [println]. This is
+ *   equivalent to the pre-#268 behavior (errors are printed to stdout; the format now
+ *   includes the full stack trace).
  *
  *   To silence diagnostics entirely, pass `onError = {}`.
  *   To route through your own logger, pass e.g. `onError = { Timber.w(it) }`.
@@ -481,19 +482,19 @@ public fun FeatureFlagsDebugScreen(
                                 FlagItemCard(
                                     item = item,
                                     onToggleBoolean = { newValue ->
-                                        launchCatching(scope, onError, "Failed to override '${item.key}'") {
+                                        launchCatching(scope, onError, "Failed to override '${item.key}' (boolean)") {
                                             @Suppress("UNCHECKED_CAST")
                                             configValues.override(item.param as ConfigParam<Boolean>, newValue)
                                         }
                                     },
                                     onScalarInput = { newValue ->
-                                        launchCatching(scope, onError, "Failed to override '${item.key}'") {
+                                        launchCatching(scope, onError, "Failed to override '${item.key}' (scalar)") {
                                             @Suppress("UNCHECKED_CAST")
                                             configValues.override(item.param as ConfigParam<Any>, newValue)
                                         }
                                     },
                                     onEnumSelect = { newValue ->
-                                        launchCatching(scope, onError, "Failed to override '${item.key}'") {
+                                        launchCatching(scope, onError, "Failed to override '${item.key}' (enum)") {
                                             @Suppress("UNCHECKED_CAST")
                                             configValues.override(item.param as ConfigParam<Any>, newValue)
                                         }

--- a/featured-debug-ui/src/commonMain/kotlin/dev/androidbroadcast/featured/debugui/FeatureFlagsDebugScreen.kt
+++ b/featured-debug-ui/src/commonMain/kotlin/dev/androidbroadcast/featured/debugui/FeatureFlagsDebugScreen.kt
@@ -91,6 +91,20 @@ import kotlin.coroutines.cancellation.CancellationException
  *   stable top-level `val` or `object` property for predictable behavior.
  *   Each [ConfigParam.key] must be unique within the list; duplicates cause a
  *   runtime crash in `LazyColumn` key collision.
+ * @param onError Callback invoked when a non-fatal internal error occurs — for example,
+ *   a provider failure while building a flag item, a dead collector, or a failed
+ *   override / reset operation. The screen recovers from all these errors without
+ *   crashing; this callback is the hook to observe or log them.
+ *
+ *   Default behavior: prints the full stack trace to stdout via [println], which is the
+ *   same as the pre-#268 behavior.
+ *
+ *   To silence diagnostics entirely, pass `onError = {}`.
+ *   To route through your own logger, pass e.g. `onError = { Timber.w(it) }`.
+ *
+ *   **The callback must not throw.** Any exception thrown from it is swallowed so that
+ *   the screen continues to function. Throwing inside the callback will suppress the
+ *   original error context — prefer logging over re-throwing.
  * @param modifier Optional [Modifier] for the root composable.
  */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -99,6 +113,7 @@ import kotlin.coroutines.cancellation.CancellationException
 public fun FeatureFlagsDebugScreen(
     configValues: ConfigValues,
     registry: List<ConfigParam<*>>,
+    onError: (Throwable) -> Unit = { e -> println("Featured debug-ui: ${e.stackTraceToString()}") },
     modifier: Modifier = Modifier,
 ) {
     val scope = rememberCoroutineScope()
@@ -152,8 +167,9 @@ public fun FeatureFlagsDebugScreen(
                                 runCatching { buildDebugItemForParam(configValues, param) }
                                     .onFailure { e ->
                                         if (e is CancellationException) throw e
-                                        println(
-                                            "Featured debug-ui: failed to build item for '${param.key}': $e",
+                                        reportError(
+                                            onError,
+                                            debugUiError("Failed to build item for '${param.key}'", e),
                                         )
                                     }.getOrNull()
                             }
@@ -181,7 +197,7 @@ public fun FeatureFlagsDebugScreen(
                     throw e
                 } catch (e: Exception) {
                     // Slot stays stale; screen remains functional for other params.
-                    println("Featured debug-ui: collector died for '${param.key}': $e")
+                    reportError(onError, debugUiError("Collector died for '${param.key}'", e))
                 }
             }
         }
@@ -241,8 +257,9 @@ public fun FeatureFlagsDebugScreen(
                                             }.onFailure { e ->
                                                 if (e is CancellationException) throw e
                                                 failedKeys += entry.param.key
-                                                println(
-                                                    "Featured debug-ui: failed to reset override for '${entry.param.key}': $e",
+                                                reportError(
+                                                    onError,
+                                                    debugUiError("Failed to reset '${entry.param.key}'", e),
                                                 )
                                             }
                                         }
@@ -280,8 +297,9 @@ public fun FeatureFlagsDebugScreen(
                                                             }.onFailure { e ->
                                                                 if (e is CancellationException) throw e
                                                                 undoFailed += entry.param.key
-                                                                println(
-                                                                    "Featured debug-ui: failed to restore override for '${entry.param.key}': $e",
+                                                                reportError(
+                                                                    onError,
+                                                                    debugUiError("Failed to restore '${entry.param.key}'", e),
                                                                 )
                                                             }
                                                         }
@@ -474,8 +492,9 @@ public fun FeatureFlagsDebugScreen(
                                                 )
                                             }.onFailure { e ->
                                                 if (e is CancellationException) throw e
-                                                println(
-                                                    "Featured debug-ui: failed to write boolean override for '${item.key}': $e",
+                                                reportError(
+                                                    onError,
+                                                    debugUiError("Failed to override '${item.key}'", e),
                                                 )
                                             }
                                         }
@@ -490,8 +509,9 @@ public fun FeatureFlagsDebugScreen(
                                                 )
                                             }.onFailure { e ->
                                                 if (e is CancellationException) throw e
-                                                println(
-                                                    "Featured debug-ui: failed to write scalar override for '${item.key}': $e",
+                                                reportError(
+                                                    onError,
+                                                    debugUiError("Failed to override '${item.key}'", e),
                                                 )
                                             }
                                         }
@@ -506,8 +526,9 @@ public fun FeatureFlagsDebugScreen(
                                                 )
                                             }.onFailure { e ->
                                                 if (e is CancellationException) throw e
-                                                println(
-                                                    "Featured debug-ui: failed to write enum override for '${item.key}': $e",
+                                                reportError(
+                                                    onError,
+                                                    debugUiError("Failed to override '${item.key}'", e),
                                                 )
                                             }
                                         }
@@ -518,8 +539,9 @@ public fun FeatureFlagsDebugScreen(
                                                 configValues.resetOverride(item.param)
                                             }.onFailure { e ->
                                                 if (e is CancellationException) throw e
-                                                println(
-                                                    "Featured debug-ui: failed to reset override for '${item.key}': $e",
+                                                reportError(
+                                                    onError,
+                                                    debugUiError("Failed to reset '${item.key}'", e),
                                                 )
                                             }
                                         }
@@ -536,6 +558,32 @@ public fun FeatureFlagsDebugScreen(
 
 /** Returns "1 override" or "N overrides" for use in dialog titles and snackbar messages. */
 private fun overrideLabel(count: Int): String = if (count == 1) "1 override" else "$count overrides"
+
+/**
+ * Wraps [cause] in an [IllegalStateException] with a human-readable [message] that
+ * describes which flag key was involved. The resulting throwable is passed to the
+ * caller-supplied [FeatureFlagsDebugScreen] `onError` callback.
+ */
+internal fun debugUiError(
+    message: String,
+    cause: Throwable,
+): Throwable = IllegalStateException(message, cause)
+
+/**
+ * Invokes [onError] with the given [throwable] and swallows any exception thrown by the
+ * callback so that the debug screen remains functional. The callback must not throw;
+ * any exception from it is silently discarded here.
+ */
+internal fun reportError(
+    onError: (Throwable) -> Unit,
+    throwable: Throwable,
+) {
+    try {
+        onError(throwable)
+    } catch (_: Throwable) {
+        // Swallowed: a throwing onError must not break the screen.
+    }
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/featured-debug-ui/src/commonMain/kotlin/dev/androidbroadcast/featured/debugui/FeatureFlagsDebugScreen.kt
+++ b/featured-debug-ui/src/commonMain/kotlin/dev/androidbroadcast/featured/debugui/FeatureFlagsDebugScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.unit.dp
 import dev.androidbroadcast.featured.ConfigParam
 import dev.androidbroadcast.featured.ConfigValue
 import dev.androidbroadcast.featured.ConfigValues
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -281,31 +282,28 @@ public fun FeatureFlagsDebugScreen(
                                 )
                             if (result == SnackbarResult.ActionPerformed) {
                                 // Undo: restore all snapshotted values in parallel.
-                                val undoFailCount =
-                                    mutableListOf<String>()
-                                        .also { undoFailed ->
-                                            coroutineScope {
-                                                plan
-                                                    .map { entry ->
-                                                        async {
-                                                            runCatching {
-                                                                @Suppress("UNCHECKED_CAST")
-                                                                configValues.override(
-                                                                    entry.param as ConfigParam<Any>,
-                                                                    entry.previousValue,
-                                                                )
-                                                            }.onFailure { e ->
-                                                                if (e is CancellationException) throw e
-                                                                undoFailed += entry.param.key
-                                                                reportError(
-                                                                    onError,
-                                                                    debugUiError("Failed to restore '${entry.param.key}'", e),
-                                                                )
-                                                            }
-                                                        }
-                                                    }.forEach { it.await() }
+                                var undoFailCount = 0
+                                coroutineScope {
+                                    plan
+                                        .map { entry ->
+                                            async {
+                                                runCatching {
+                                                    @Suppress("UNCHECKED_CAST")
+                                                    configValues.override(
+                                                        entry.param as ConfigParam<Any>,
+                                                        entry.previousValue,
+                                                    )
+                                                }.onFailure { e ->
+                                                    if (e is CancellationException) throw e
+                                                    undoFailCount++
+                                                    reportError(
+                                                        onError,
+                                                        debugUiError("Failed to restore '${entry.param.key}'", e),
+                                                    )
+                                                }
                                             }
-                                        }.size
+                                        }.forEach { it.await() }
+                                }
                                 if (undoFailCount > 0) {
                                     val restoredCount = plan.size - undoFailCount
                                     snackbarHostState.showSnackbar(
@@ -483,67 +481,26 @@ public fun FeatureFlagsDebugScreen(
                                 FlagItemCard(
                                     item = item,
                                     onToggleBoolean = { newValue ->
-                                        scope.launch {
-                                            runCatching {
-                                                @Suppress("UNCHECKED_CAST")
-                                                configValues.override(
-                                                    item.param as ConfigParam<Boolean>,
-                                                    newValue,
-                                                )
-                                            }.onFailure { e ->
-                                                if (e is CancellationException) throw e
-                                                reportError(
-                                                    onError,
-                                                    debugUiError("Failed to override '${item.key}'", e),
-                                                )
-                                            }
+                                        launchCatching(scope, onError, "Failed to override '${item.key}'") {
+                                            @Suppress("UNCHECKED_CAST")
+                                            configValues.override(item.param as ConfigParam<Boolean>, newValue)
                                         }
                                     },
                                     onScalarInput = { newValue ->
-                                        scope.launch {
-                                            runCatching {
-                                                @Suppress("UNCHECKED_CAST")
-                                                configValues.override(
-                                                    item.param as ConfigParam<Any>,
-                                                    newValue,
-                                                )
-                                            }.onFailure { e ->
-                                                if (e is CancellationException) throw e
-                                                reportError(
-                                                    onError,
-                                                    debugUiError("Failed to override '${item.key}'", e),
-                                                )
-                                            }
+                                        launchCatching(scope, onError, "Failed to override '${item.key}'") {
+                                            @Suppress("UNCHECKED_CAST")
+                                            configValues.override(item.param as ConfigParam<Any>, newValue)
                                         }
                                     },
                                     onEnumSelect = { newValue ->
-                                        scope.launch {
-                                            runCatching {
-                                                @Suppress("UNCHECKED_CAST")
-                                                configValues.override(
-                                                    item.param as ConfigParam<Any>,
-                                                    newValue,
-                                                )
-                                            }.onFailure { e ->
-                                                if (e is CancellationException) throw e
-                                                reportError(
-                                                    onError,
-                                                    debugUiError("Failed to override '${item.key}'", e),
-                                                )
-                                            }
+                                        launchCatching(scope, onError, "Failed to override '${item.key}'") {
+                                            @Suppress("UNCHECKED_CAST")
+                                            configValues.override(item.param as ConfigParam<Any>, newValue)
                                         }
                                     },
                                     onResetToDefault = {
-                                        scope.launch {
-                                            runCatching {
-                                                configValues.resetOverride(item.param)
-                                            }.onFailure { e ->
-                                                if (e is CancellationException) throw e
-                                                reportError(
-                                                    onError,
-                                                    debugUiError("Failed to reset '${item.key}'", e),
-                                                )
-                                            }
+                                        launchCatching(scope, onError, "Failed to reset '${item.key}'") {
+                                            configValues.resetOverride(item.param)
                                         }
                                     },
                                 )
@@ -558,6 +515,25 @@ public fun FeatureFlagsDebugScreen(
 
 /** Returns "1 override" or "N overrides" for use in dialog titles and snackbar messages. */
 private fun overrideLabel(count: Int): String = if (count == 1) "1 override" else "$count overrides"
+
+/**
+ * Launches a coroutine on [scope], runs [block], and forwards any non-cancellation exception
+ * to [onError] via [reportError]. Cancellation exceptions are re-thrown to preserve structured
+ * concurrency.
+ */
+private fun launchCatching(
+    scope: CoroutineScope,
+    onError: (Throwable) -> Unit,
+    errorMessage: String,
+    block: suspend () -> Unit,
+) {
+    scope.launch {
+        runCatching { block() }.onFailure { e ->
+            if (e is CancellationException) throw e
+            reportError(onError, debugUiError(errorMessage, e))
+        }
+    }
+}
 
 /**
  * Wraps [cause] in an [IllegalStateException] with a human-readable [message] that

--- a/featured-debug-ui/src/commonTest/kotlin/dev/androidbroadcast/featured/debugui/ErrorReportingTest.kt
+++ b/featured-debug-ui/src/commonTest/kotlin/dev/androidbroadcast/featured/debugui/ErrorReportingTest.kt
@@ -1,9 +1,10 @@
 package dev.androidbroadcast.featured.debugui
 
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class ErrorReportingTest {
@@ -20,9 +21,12 @@ class ErrorReportingTest {
     }
 
     @Test
-    fun debugUiError_messageContainsKey() {
-        val error = debugUiError("Failed to reset 'some_key'", RuntimeException())
-        assertTrue(error.message!!.contains("some_key"))
+    fun debugUiError_causeNotReWrapped() {
+        // The original cause must be available directly via .cause — debugUiError must
+        // not wrap the cause in a second layer of exceptions.
+        val original = RuntimeException("root cause")
+        val error = debugUiError("Failed to reset 'some_key'", original)
+        assertSame(original, error.cause)
     }
 
     // --- reportError ---
@@ -47,6 +51,19 @@ class ErrorReportingTest {
             throwable = throwable,
         )
         // If we reach here, the exception was swallowed correctly.
+    }
+
+    @Test
+    fun reportError_swallowsCancellationExceptionFromCallback() {
+        // CancellationException thrown BY the callback is also swallowed — the catch
+        // clause is `catch (Throwable)`, not `catch (Exception)`. This pins the
+        // regression: narrowing to Exception would let CE escape and kill the scope.
+        val throwable = debugUiError("msg", RuntimeException())
+        reportError(
+            onError = { throw CancellationException("callback cancelled") },
+            throwable = throwable,
+        )
+        // If we reach here, the CancellationException was swallowed correctly.
     }
 
     @Test

--- a/featured-debug-ui/src/commonTest/kotlin/dev/androidbroadcast/featured/debugui/ErrorReportingTest.kt
+++ b/featured-debug-ui/src/commonTest/kotlin/dev/androidbroadcast/featured/debugui/ErrorReportingTest.kt
@@ -50,7 +50,7 @@ class ErrorReportingTest {
     }
 
     @Test
-    fun reportError_nullReceivedWhenCallbackThrows() {
+    fun reportError_callbackInvokedBeforeThrow() {
         var received: Throwable? = null
         val throwable = debugUiError("msg", RuntimeException())
 

--- a/featured-debug-ui/src/commonTest/kotlin/dev/androidbroadcast/featured/debugui/ErrorReportingTest.kt
+++ b/featured-debug-ui/src/commonTest/kotlin/dev/androidbroadcast/featured/debugui/ErrorReportingTest.kt
@@ -1,0 +1,75 @@
+package dev.androidbroadcast.featured.debugui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ErrorReportingTest {
+    // --- debugUiError ---
+
+    @Test
+    fun debugUiError_wrapsMessageAndCause() {
+        val cause = RuntimeException("provider failed")
+        val error = debugUiError("Failed to build item for 'my_flag'", cause)
+
+        assertIs<IllegalStateException>(error)
+        assertTrue(error.message!!.contains("my_flag"))
+        assertEquals(cause, error.cause)
+    }
+
+    @Test
+    fun debugUiError_messageContainsKey() {
+        val error = debugUiError("Failed to reset 'some_key'", RuntimeException())
+        assertTrue(error.message!!.contains("some_key"))
+    }
+
+    // --- reportError ---
+
+    @Test
+    fun reportError_invokesCallback() {
+        var received: Throwable? = null
+        val throwable = debugUiError("Failed to override 'flag'", RuntimeException())
+
+        reportError(onError = { received = it }, throwable = throwable)
+
+        assertEquals(throwable, received)
+    }
+
+    @Test
+    fun reportError_swallowsExceptionFromCallback() {
+        val throwable = debugUiError("Collector died for 'flag'", RuntimeException())
+
+        // A throwing callback must not propagate — the screen must remain functional.
+        reportError(
+            onError = { throw IllegalStateException("callback blew up") },
+            throwable = throwable,
+        )
+        // If we reach here, the exception was swallowed correctly.
+    }
+
+    @Test
+    fun reportError_nullReceivedWhenCallbackThrows() {
+        var received: Throwable? = null
+        val throwable = debugUiError("msg", RuntimeException())
+
+        reportError(
+            onError = {
+                received = it
+                throw RuntimeException("boom")
+            },
+            throwable = throwable,
+        )
+
+        // Callback was invoked before throwing — received is set.
+        assertEquals(throwable, received)
+    }
+
+    @Test
+    fun reportError_noopCallbackIsValid() {
+        // Verifies the silence pattern `onError = {}` compiles and does not crash.
+        val throwable = debugUiError("msg", RuntimeException())
+        reportError(onError = {}, throwable = throwable)
+    }
+}


### PR DESCRIPTION
Closes #268

## What
- New optional `onError: (Throwable) -> Unit` parameter on `FeatureFlagsDebugScreen` — mirrors core's `ConfigValues.onProviderError` contract (pass `{}` to silence; the callback must not throw — exceptions from it are swallowed). No new dependency.
- All 8 former `println` sites (initial item build, collector death, boolean/scalar/enum override writes, reset, undo) now route through the callback with key-bearing context messages (`Failed to override 'key' (boolean)` etc.); `CancellationException` is rethrown before reporting everywhere.
- Default preserves pre-#268 behavior (errors printed to stdout; format now includes the full stack trace).
- Additive public API; existing named-arg call sites compile unchanged (positional `modifier` callers get a loud type error, not a silent break).

## Verification
- 7 commonTest cases for the error funnel (wrapping, no re-wrap of cause, swallow incl. CancellationException from the callback, invocation ordering); jvmTest/iOS/sample compile green.
- finalize PASS (A+B+C trio+D architecture 92/100), acceptance: contract verified vs issue (option 2 implemented as recommended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)