### PR TITLE
ci: disable SNAPSHOT publish on branch push, gate on workflow_dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,10 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-*"
-    branches:
-      - main
-      - develop
+  # SNAPSHOT publishing on branch push is disabled: Central Portal namespace dev.androidbroadcast
+  # does not have SNAPSHOT deployment enabled — every push 403s. Re-add the branches trigger
+  # (main/develop) after enabling SNAPSHOT support in Portal settings. Issue #223.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -50,7 +51,7 @@ jobs:
           ORG_GRADLE_PROJECT_VERSION_NAME: ${{ steps.version.outputs.VERSION_NAME }}
         # On a version tag: uploads the deployment bundle to the Sonatype Central Portal as
         # USER_MANAGED — the deployment must be promoted to release manually in the Portal UI.
-        # On SNAPSHOT branch pushes: uploads to the snapshots repo.
+        # On workflow_dispatch (manual): publishes a SNAPSHOT version (requires Portal SNAPSHOT support enabled).
         # --no-configuration-cache for release-pipeline debuggability (runs once per tag, CC savings are zero).
         run: ./gradlew --no-daemon publishToMavenCentral --no-configuration-cache
 


### PR DESCRIPTION
## Root cause

`publish.yml` was triggered on every push to `develop`/`main` in addition to version tags. On branch pushes the workflow computes a `-SNAPSHOT` version and calls `publishToMavenCentral`, which hits the Sonatype Central Portal snapshots endpoint. The `dev.androidbroadcast` namespace does not have SNAPSHOT deployment enabled on the new Central Portal — the request is rejected with HTTP 403. Every push produced a failing Publish check, training maintainers to ignore red CI.

Reference failed runs from the issue: `26701975087`, `26694180198`, and every run on `develop` since then.

## What changed

- Removed `branches: [main, develop]` from the `push:` trigger in `publish.yml`.
- Added `workflow_dispatch:` so a SNAPSHOT publish can still be triggered manually when needed.
- Updated the inline comment on the publish step to reflect the new trigger model.
- The `push: tags:` trigger and the entire release path (`publish` job on tags, `publish-xcframework` job) are **untouched**.

## What did NOT change

- Release publish on version tags (`v*.*.*`) works exactly as before.
- XCFramework job is unaffected — it already had `if: startsWith(github.ref, 'refs/tags/')`.
- All secrets, signing, and USER_MANAGED upload logic are unchanged.

## Alternative

Enable SNAPSHOT deployment for namespace `dev.androidbroadcast` in Central Portal settings (`central.sonatype.com → Namespaces`), then restore the `branches` trigger. That is a Portal-side action and is the right long-term fix if SNAPSHOT publishing is actually needed.

Refs #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/androidbroadcast/Featured/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

