### PR TITLE
Fix toCamelCase keeping uppercase tail for multi-word ALL_CAPS keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ProGuard `-assumevalues` rules and iOS const-val files follow the local section's effective package,
   keeping release-build DCE intact with custom packages.
 
+### Fixed
+
+- Gradle plugin: `toCamelCase` conversion now fully lowercases each word before capitalising
+  the first letter, so ALL_CAPS flag keys produce correct camelCase names.
+  `DARK_MODE` → `darkMode` (was `darkMODE`), `NEW_CHECKOUT_FLOW` → `newCheckoutFlow`
+  (was `newCHECKOUTFLOW`). **Generated function/property names change for any multi-word
+  ALL_CAPS flag key** (e.g. `isDarkMODEEnabled` → `isDarkModeEnabled`). (#248)
+
 ### Changed
 
 - `ConfigValues` now reads **both** providers before resolving a value; previously the remote

--- a/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/FlagEntryUtils.kt
+++ b/featured-gradle-plugin/src/main/kotlin/dev/androidbroadcast/featured/gradle/FlagEntryUtils.kt
@@ -3,15 +3,16 @@ package dev.androidbroadcast.featured.gradle
 /**
  * Converts a snake_case key string to a camelCase Kotlin property name.
  *
- * Examples:
- * - `"dark_mode"` → `"darkMode"`
- * - `"new_checkout_flow"` → `"newCheckoutFlow"`
+ * Each segment is fully lowercased before capitalisation so that ALL_CAPS inputs
+ * produce the same result as their lowercase equivalents:
+ * - `"DARK_MODE"` and `"dark_mode"` both yield `"darkMode"`
+ * - `"NEW_CHECKOUT_FLOW"` → `"newCheckoutFlow"`
  * - `"enabled"` → `"enabled"`
  */
 internal fun String.toCamelCase(): String =
     split("_")
         .mapIndexed { index, word ->
-            if (index == 0) word.lowercase() else word.replaceFirstChar { it.uppercase() }
+            if (index == 0) word.lowercase() else word.lowercase().replaceFirstChar { it.uppercase() }
         }.joinToString("")
 
 /**

--- a/featured-gradle-plugin/src/test/kotlin/dev/androidbroadcast/featured/gradle/FlagEntryUtilsTest.kt
+++ b/featured-gradle-plugin/src/test/kotlin/dev/androidbroadcast/featured/gradle/FlagEntryUtilsTest.kt
@@ -22,13 +22,28 @@ class FlagEntryUtilsTest {
     }
 
     @Test
-    fun `toCamelCase all uppercase input lowercases first segment capitalises rest`() {
-        assertEquals("darkMODE", "DARK_MODE".toCamelCase())
+    fun `toCamelCase two words ALL_CAPS`() {
+        assertEquals("darkMode", "DARK_MODE".toCamelCase())
+    }
+
+    @Test
+    fun `toCamelCase three words ALL_CAPS`() {
+        assertEquals("newCheckoutFlow", "NEW_CHECKOUT_FLOW".toCamelCase())
+    }
+
+    @Test
+    fun `toCamelCase single word ALL_CAPS`() {
+        assertEquals("debug", "DEBUG".toCamelCase())
     }
 
     @Test
     fun `toCamelCase no underscores lowercases entire string`() {
         assertEquals("darkmode", "darkMode".toCamelCase())
+    }
+
+    @Test
+    fun `toCamelCase mixed case with underscore`() {
+        assertEquals("darkMode", "dark_mode".toCamelCase())
     }
 
     // ── modulePathToIdentifier ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `toCamelCase` now fully lowercases each segment before capitalising the first character.
- `DARK_MODE` → `darkMode` (was `darkMODE`), `NEW_CHECKOUT_FLOW` → `newCheckoutFlow` (was `newCHECKOUTFLOW`).
- Added test cases for ALL_CAPS multi-word keys, single-word ALL_CAPS, and mixed-case inputs.

## Breaking change

Generated function/property names change for any multi-word ALL_CAPS flag key declared via the `featured { }` DSL. Examples:
- `isDarkMODEEnabled` → `isDarkModeEnabled`
- `isNewCHECKOUTFLOWEnabled` → `isNewCheckoutFlowEnabled`

Consumers must update call sites after upgrading.

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/androidbroadcast/Featured/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

