### PR TITLE
Document compileSdk 37 requirement in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   own package and visibility. The ProGuard `-assumevalues` class name changed accordingly; both the
   sources and the rules are regenerated together by the plugin, so no consumer action is required.
   (#278)
+- Dependency updates raised `androidx.core` to 1.19.0, which requires Android consumers to build
+  with `compileSdk 37` or higher; the library itself now compiles with `compileSdk 37`. (#282)
 
 ## [1.1.1] - 2026-06-04
 


### PR DESCRIPTION
Adds a `### Changed` entry to the `[Unreleased]` section noting that the `androidx.core` 1.19.0 bump (#282) requires Android consumers to build with `compileSdk 37` or higher.

No code changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/androidbroadcast/Featured/pull/283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

