### PR TITLE
Bump Android Gradle Plugin to 9.2.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.1.0"
+agp = "9.2.1"
 android-compileSdk = "37"
 android-minSdk = "24"
 android-targetSdk = "36"
@@ -33,7 +33,7 @@ pluginPublish = "2.1.1"
 dokka = "2.2.0"
 detekt = "1.23.8"
 configcat = "5.1.0"
-lint = "32.1.0" # Must equal AGP version + 23.0.0 (e.g., AGP 9.1.0 → Lint 32.1.0)
+lint = "32.2.1" # Must equal AGP version + 23.0.0 (e.g., AGP 9.2.1 → Lint 32.2.1)
 r8 = "9.1.31"
 asm = "9.10.1"
 


### PR DESCRIPTION
## Summary

- Bumps AGP from 9.1.0 to 9.2.1 in `gradle/libs.versions.toml`
- Affected plugin aliases: `androidApplication` (com.android.application), `androidLibrary` (com.android.library), `androidKmpLibrary` (com.android.kotlin.multiplatform.library) — all share the `agp` version ref
- Co-bumps `lint` 32.1.0 → 32.2.1 (inline formula: AGP version + 23.0.0; updated comment to match)

## Gradle wrapper compatibility

Wrapper is pinned at **Gradle 9.4.1** — no bump required. AGP 9.2.x minimum is Gradle 8.10+, which 9.4.1 satisfies.

## Verification

Commands run and results:

| Command | Result |
|---|---|
| `./gradlew spotlessCheck --no-daemon` | BUILD SUCCESSFUL (45s) |
| `./gradlew :sample:android-app:assembleDebug --no-daemon` | BUILD SUCCESSFUL (1m 29s) |
| `./gradlew :core:tasks :providers:sharedpreferences:tasks --no-daemon` | BUILD SUCCESSFUL (28s) |

No build errors or new warnings attributable to the AGP bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/androidbroadcast/Featured/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

