### PR TITLE
Implement InitializableConfigValueProvider on Firebase provider

### DIFF
--- a/providers/firebase/src/main/kotlin/dev/androidbroadcast/featured/firebase/FirebaseConfigValueProvider.kt
+++ b/providers/firebase/src/main/kotlin/dev/androidbroadcast/featured/firebase/FirebaseConfigValueProvider.kt
@@ -4,6 +4,7 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue
 import dev.androidbroadcast.featured.ConfigParam
 import dev.androidbroadcast.featured.ConfigValue
+import dev.androidbroadcast.featured.InitializableConfigValueProvider
 import dev.androidbroadcast.featured.RemoteConfigValueProvider
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.tasks.await
@@ -28,7 +29,8 @@ import kotlin.reflect.KClass
  */
 public class FirebaseConfigValueProvider(
     private val remoteConfig: FirebaseRemoteConfig = FirebaseRemoteConfig.getInstance(),
-) : RemoteConfigValueProvider {
+) : RemoteConfigValueProvider,
+    InitializableConfigValueProvider {
     /**
      * Mutable registry of type converters used to extract typed values from Firebase.
      *
@@ -79,6 +81,30 @@ public class FirebaseConfigValueProvider(
         }
 
         throw IllegalStateException("No converter registered for type: $type")
+    }
+
+    /**
+     * Loads the persisted Remote Config data into memory so that values are immediately
+     * readable via [get] without a network round-trip.
+     *
+     * Internally calls [FirebaseRemoteConfig.ensureInitialized], which warms Firebase's
+     * on-disk caches (activated, fetched, and defaults) into the in-process cache.
+     * This does NOT perform a network fetch — call [fetch] for that.
+     * This does NOT activate fetched-but-unactivated config — use [fetch] with `activate = true`
+     * or call `FirebaseRemoteConfig.activate()` directly when activation is desired.
+     *
+     * @throws FetchException if [FirebaseRemoteConfig.ensureInitialized] fails.
+     * @throws kotlinx.coroutines.CancellationException if the coroutine is cancelled; propagated
+     *   without wrapping.
+     */
+    override suspend fun initialize() {
+        try {
+            remoteConfig.ensureInitialized().await()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw FetchException("Firebase Remote Config initialize failed", e)
+        }
     }
 
     /**

--- a/providers/firebase/src/test/kotlin/dev/androidbroadcast/featured/firebase/FirebaseConfigValueProviderTest.kt
+++ b/providers/firebase/src/test/kotlin/dev/androidbroadcast/featured/firebase/FirebaseConfigValueProviderTest.kt
@@ -8,12 +8,14 @@ import dev.androidbroadcast.featured.ConfigValue
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 
 class FirebaseConfigValueProviderTest {
     private lateinit var remoteConfig: FirebaseRemoteConfig
@@ -232,6 +234,47 @@ class FirebaseConfigValueProviderTest {
             every { remoteConfig.getValue("custom_key") } returns mockValue
 
             assertFailsWith<IllegalStateException> { provider.get(param) }
+        }
+
+    // --- initialize() behaviour ---
+
+    @Test
+    fun `initialize calls ensureInitialized exactly once`() =
+        runTest {
+            every { remoteConfig.ensureInitialized() } returns Tasks.forResult(mockk(relaxed = true))
+
+            provider.initialize()
+
+            verify(exactly = 1) { remoteConfig.ensureInitialized() }
+        }
+
+    @Test
+    fun `initialize does not call fetch or fetchAndActivate`() =
+        runTest {
+            every { remoteConfig.ensureInitialized() } returns Tasks.forResult(mockk(relaxed = true))
+
+            provider.initialize()
+
+            verify(exactly = 0) { remoteConfig.fetch() }
+            verify(exactly = 0) { remoteConfig.fetchAndActivate() }
+        }
+
+    @Test
+    fun `initialize wraps task failure in FetchException`() =
+        runTest {
+            val cause = RuntimeException("disk read error")
+            every { remoteConfig.ensureInitialized() } returns Tasks.forException(cause)
+
+            val ex = assertFailsWith<FetchException> { provider.initialize() }
+            assertSame(cause, ex.cause)
+        }
+
+    @Test
+    fun `initialize rethrows CancellationException without wrapping in FetchException`() =
+        runTest {
+            every { remoteConfig.ensureInitialized() } returns Tasks.forException(CancellationException("cancelled"))
+
+            assertFailsWith<CancellationException> { provider.initialize() }
         }
 
     // --- fetch() behaviour ---


### PR DESCRIPTION
## Summary

Implements `InitializableConfigValueProvider` on `FirebaseConfigValueProvider` (closes #163). This was deferred from v1.0.0 pending the API-design decision on `initialize()` semantics.

`initialize()` calls `FirebaseRemoteConfig.ensureInitialized().await()`, which warms Firebase's on-disk caches (activated / fetched / defaults) into memory **without a network fetch**. After it, `ConfigValues.get()` reads the persisted values synchronously from memory (`Source.REMOTE`), enabling instant flag values at app start before the first `fetch()`.

## Design decision

`ensureInitialized()` **only** — confirmed with the maintainer. Rejected `+ activate()`: `activate()` would auto-promote config that was deliberately fetched-but-not-activated via `fetch(activate = false)`, changing `initialize()`'s semantics from "warm the cache" to "warm + auto-activate" — a footgun. `ensureInitialized()` is the literal match of the interface contract ("load previously cached values, MUST NOT fetch") and does not mutate state.

Error handling mirrors the existing `fetch()`: `CancellationException` is re-thrown unwrapped; other exceptions are wrapped in `FetchException` with the original `cause` preserved.

## Tests

4 unit tests (mockk + `runTest`):
- `ensureInitialized()` called exactly once
- `fetch()` / `fetchAndActivate()` NOT called (no network)
- task failure wrapped in `FetchException` with `cause` preserved
- `CancellationException` re-thrown without wrapping

`:providers:firebase:testDebugUnitTest` — 26/26 green; `compileDebugKotlin` green; spotless clean.

> Note: the firebase module's kover threshold is intentionally 0 (#45) — runtime verification against a real Firebase backend is out of scope; the contract is covered by mockk unit tests.

## Follow-up (out of scope)

`FetchException` is fetch-oriented in name but reused for `initialize()` errors. Consider renaming to a neutral `ProviderException` in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/androidbroadcast/Featured/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

