### PR TITLE
Rename firebase FetchException to FirebaseConfigException

### DIFF
--- a/providers/firebase/src/main/kotlin/dev/androidbroadcast/featured/firebase/FirebaseConfigException.kt
+++ b/providers/firebase/src/main/kotlin/dev/androidbroadcast/featured/firebase/FirebaseConfigException.kt
@@ -1,16 +1,17 @@
 package dev.androidbroadcast.featured.firebase
 
 /**
- * Thrown when a Firebase Remote Config fetch operation fails.
+ * Thrown when a Firebase Remote Config operation fails.
  *
  * This exception wraps any underlying error (e.g. network failure, timeout, or
- * Firebase service error) that occurs during [FirebaseConfigValueProvider.fetch].
+ * Firebase service error) that occurs during any [FirebaseConfigValueProvider] operation,
+ * including [FirebaseConfigValueProvider.initialize] and [FirebaseConfigValueProvider.fetch].
  *
  * ## Retry recommendation
  *
  * Firebase Remote Config applies its own throttle limits; callers should not retry
- * immediately on every failure. A typical strategy is:
- * - Catch [FetchException] and log the [cause] for diagnostics.
+ * immediately on every fetch failure. A typical strategy is:
+ * - Catch [FirebaseConfigException] and log the [cause] for diagnostics.
  * - Retry only on subsequent app launches or after a significant delay (e.g. 1 hour).
  * - Use `FirebaseRemoteConfigSettings.minimumFetchIntervalInSeconds` to control
  *   how aggressively Firebase fetches from the server.
@@ -18,7 +19,7 @@ package dev.androidbroadcast.featured.firebase
  * @param message A human-readable description of the failure.
  * @param cause The underlying exception that triggered this failure.
  */
-public class FetchException(
+public class FirebaseConfigException(
     message: String,
     cause: Throwable,
 ) : Exception(message, cause)

--- a/providers/firebase/src/main/kotlin/dev/androidbroadcast/featured/firebase/FirebaseConfigValueProvider.kt
+++ b/providers/firebase/src/main/kotlin/dev/androidbroadcast/featured/firebase/FirebaseConfigValueProvider.kt
@@ -93,7 +93,7 @@ public class FirebaseConfigValueProvider(
      * This does NOT activate fetched-but-unactivated config — use [fetch] with `activate = true`
      * or call `FirebaseRemoteConfig.activate()` directly when activation is desired.
      *
-     * @throws FetchException if [FirebaseRemoteConfig.ensureInitialized] fails.
+     * @throws FirebaseConfigException if [FirebaseRemoteConfig.ensureInitialized] fails.
      * @throws kotlinx.coroutines.CancellationException if the coroutine is cancelled; propagated
      *   without wrapping.
      */
@@ -103,7 +103,7 @@ public class FirebaseConfigValueProvider(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            throw FetchException("Firebase Remote Config initialize failed", e)
+            throw FirebaseConfigException("Firebase Remote Config initialize failed", e)
         }
     }
 
@@ -112,11 +112,11 @@ public class FirebaseConfigValueProvider(
      *
      * @param activate When `true`, calls `fetchAndActivate()` so values become available
      *   immediately after this call. When `false`, only fetches without activating.
-     * @throws FetchException if the Firebase fetch operation fails for any reason, including
+     * @throws FirebaseConfigException if the Firebase fetch operation fails for any reason, including
      *   network errors, timeouts, or service unavailability. This wraps all non-cancellation
      *   exceptions — including [RuntimeException] thrown by [kotlinx.coroutines.tasks.await]
-     *   on Firebase task failure. The [FetchException.cause] holds the original exception for
-     *   diagnostics. See [FetchException] for retry recommendations.
+     *   on Firebase task failure. The [FirebaseConfigException.cause] holds the original exception for
+     *   diagnostics. See [FirebaseConfigException] for retry recommendations.
      * @throws kotlinx.coroutines.CancellationException if the coroutine is cancelled while
      *   the fetch is in progress; propagated without wrapping.
      */
@@ -132,7 +132,7 @@ public class FirebaseConfigValueProvider(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            throw FetchException("Firebase Remote Config fetch failed", e)
+            throw FirebaseConfigException("Firebase Remote Config fetch failed", e)
         }
     }
 }

--- a/providers/firebase/src/test/kotlin/dev/androidbroadcast/featured/firebase/FirebaseConfigValueProviderTest.kt
+++ b/providers/firebase/src/test/kotlin/dev/androidbroadcast/featured/firebase/FirebaseConfigValueProviderTest.kt
@@ -260,17 +260,17 @@ class FirebaseConfigValueProviderTest {
         }
 
     @Test
-    fun `initialize wraps task failure in FetchException`() =
+    fun `initialize wraps task failure in FirebaseConfigException`() =
         runTest {
             val cause = RuntimeException("disk read error")
             every { remoteConfig.ensureInitialized() } returns Tasks.forException(cause)
 
-            val ex = assertFailsWith<FetchException> { provider.initialize() }
+            val ex = assertFailsWith<FirebaseConfigException> { provider.initialize() }
             assertSame(cause, ex.cause)
         }
 
     @Test
-    fun `initialize rethrows CancellationException without wrapping in FetchException`() =
+    fun `initialize rethrows CancellationException without wrapping in FirebaseConfigException`() =
         runTest {
             every { remoteConfig.ensureInitialized() } returns Tasks.forException(CancellationException("cancelled"))
 
@@ -319,7 +319,7 @@ class FirebaseConfigValueProviderTest {
             val networkError = RuntimeException("Network unavailable")
             every { remoteConfig.fetchAndActivate() } returns Tasks.forException(networkError)
 
-            assertFailsWith<FetchException> { provider.fetch(activate = true) }
+            assertFailsWith<FirebaseConfigException> { provider.fetch(activate = true) }
         }
 
     @Test
@@ -328,7 +328,7 @@ class FirebaseConfigValueProviderTest {
             val networkError = RuntimeException("Network unavailable")
             every { remoteConfig.fetch() } returns Tasks.forException(networkError)
 
-            assertFailsWith<FetchException> { provider.fetch(activate = false) }
+            assertFailsWith<FirebaseConfigException> { provider.fetch(activate = false) }
         }
 
     // --- Converters registry ---


### PR DESCRIPTION
## Summary

Renames the firebase provider's `FetchException` → `FirebaseConfigException` (closes #289).

Since #163, the exception wraps failures from both `fetch()` and `initialize()` (the latter calls `ensureInitialized()`, not a fetch), so the fetch-specific name no longer fits. The new name matches `FirebaseConfigValueProvider` and is operation-agnostic.

## Changes (firebase module only)

- `FetchException.kt` → `FirebaseConfigException.kt` (`git mv`, history preserved); class renamed.
- Class KDoc generalized: "Thrown when a Firebase Remote Config operation fails" — now covers `initialize()` and `fetch()`.
- Both throw sites + `@throws` / `[…]` KDoc references in `FirebaseConfigValueProvider.kt` updated.
- Test references and method names updated.

Pure rename — no behavioral change. `ast-index usages "FetchException"` returns empty.

## Breaking change

`FetchException` is `public` API of the firebase provider. Per project policy (no migration window) the rename goes in directly; the version number reflects it.

`:providers:firebase:compileDebugKotlin` + `testDebugUnitTest` green; spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/androidbroadcast/Featured/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

