### PR TITLE
Document #163 and #289 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   receives all internal diagnostic errors (provider failures, override write errors, reset/undo
   failures). The default behavior (print to stdout with full stack trace) is preserved; pass `{}`
   to silence. Mirrors the `ConfigValues.onProviderError` contract. (#273)
+- `FirebaseConfigValueProvider` now implements `InitializableConfigValueProvider`: `initialize()`
+  calls `FirebaseRemoteConfig.ensureInitialized()` to warm the on-disk cache (activated, fetched,
+  and defaults) into memory without a network fetch. As a result `ConfigValues.initialize()` makes
+  previously persisted Remote Config values readable via `get()` immediately at app start, before
+  the first `fetch()`. It does not activate fetched-but-unactivated config. (#163)
 
 ### Fixed
 
@@ -91,6 +96,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (#278)
 - Dependency updates raised `androidx.core` to 1.19.0, which requires Android consumers to build
   with `compileSdk 37` or higher; the library itself now compiles with `compileSdk 37`. (#282)
+- The firebase provider's `FetchException` is renamed to `FirebaseConfigException`. Since the type
+  now wraps failures from both `fetch()` and `initialize()` — not only fetches — the operation-neutral
+  name reflects its actual scope. **Breaking:** update any `catch`/references to use the new name. (#289)
 
 ### Removed
 


### PR DESCRIPTION
## Summary

Adds `[Unreleased]` changelog entries for two already-merged firebase-provider changes:

- **Added** — `FirebaseConfigValueProvider` implements `InitializableConfigValueProvider` (`initialize()` warms the on-disk cache without a network fetch). (#163)
- **Changed** — `FetchException` → `FirebaseConfigException` rename (breaking). (#289)

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/androidbroadcast/Featured/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

